### PR TITLE
feat: add API Key authentication (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ GITHUB_TOKEN=your-github-token
 # Report language: en (English) or zh (Chinese)
 # CI_AGENT_LANGUAGE=en
 
+# ── API Authentication ───────────────────────
+# Static Bearer token for protecting API endpoints.
+# When unset, auth is skipped (local dev mode).
+# CI_AGENT_API_KEY=
+
 # ── Server ───────────────────────────────────
 # Allowed origins for the backend CORS policy (comma-separated)
 # CORS_ORIGINS=http://localhost:3000

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -9,3 +9,4 @@ type: Opaque
 stringData:
   ANTHROPIC_API_KEY: "your-anthropic-api-key"    # REQUIRED: replace before apply
   GITHUB_TOKEN: "your-github-token"               # RECOMMENDED: replace before apply
+  CI_AGENT_API_KEY: ""                              # OPTIONAL: set to enable API auth

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - CI_AGENT_BASE_URL=${CI_AGENT_BASE_URL:-}
       - CI_AGENT_LANGUAGE=${CI_AGENT_LANGUAGE:-en}
       - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - CI_AGENT_API_KEY=${CI_AGENT_API_KEY:-}
       - CORS_ORIGINS=http://localhost:3000
     volumes:
       - ci-agent-data:/data/.ci-agent
@@ -35,6 +36,7 @@ services:
       - "3000:3000"
     environment:
       - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_CI_AGENT_API_KEY=${CI_AGENT_API_KEY:-}
     depends_on:
       backend:
         condition: service_healthy

--- a/src/ci_optimizer/api/auth.py
+++ b/src/ci_optimizer/api/auth.py
@@ -1,0 +1,23 @@
+"""API key authentication dependency."""
+
+import os
+
+from fastapi import HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+_security = HTTPBearer(auto_error=False)
+
+
+async def verify_api_key(
+    credentials: HTTPAuthorizationCredentials | None = Security(_security),
+) -> None:
+    """Verify the Bearer token matches CI_AGENT_API_KEY.
+
+    When CI_AGENT_API_KEY is not set, authentication is skipped entirely
+    (backward-compatible for local development).
+    """
+    api_key = os.getenv("CI_AGENT_API_KEY")
+    if not api_key:
+        return  # no key configured — skip auth
+    if credentials is None or credentials.credentials != api_key:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")

--- a/src/ci_optimizer/api/routes.py
+++ b/src/ci_optimizer/api/routes.py
@@ -3,11 +3,10 @@
 import json
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-
-from ci_optimizer.api.auth import verify_api_key
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ci_optimizer.agents.orchestrator import run_analysis
+from ci_optimizer.api.auth import verify_api_key
 from ci_optimizer.api.schemas import (  # noqa: E501 — many imports
     AgentConfigSchema,
     AnalyzeRequest,

--- a/src/ci_optimizer/api/routes.py
+++ b/src/ci_optimizer/api/routes.py
@@ -3,6 +3,8 @@
 import json
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+
+from ci_optimizer.api.auth import verify_api_key
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ci_optimizer.agents.orchestrator import run_analysis
@@ -36,7 +38,7 @@ from ci_optimizer.prefetch import prepare_context
 from ci_optimizer.report.formatter import format_json, format_summary_markdown
 from ci_optimizer.resolver import resolve_input
 
-router = APIRouter(prefix="/api")
+router = APIRouter(prefix="/api", dependencies=[Depends(verify_api_key)])
 
 
 async def get_db():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,78 @@
+"""Tests for API key authentication."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ci_optimizer.api.app import app
+from ci_optimizer.api.routes import get_db
+
+
+@pytest.fixture
+async def test_app(db_session):
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(test_app):
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestAuthNoKeyConfigured:
+    """When CI_AGENT_API_KEY is not set, all requests pass through."""
+
+    @pytest.mark.asyncio
+    async def test_api_endpoint_accessible(self, client, monkeypatch):
+        monkeypatch.delenv("CI_AGENT_API_KEY", raising=False)
+        resp = await client.get("/api/dashboard")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_health_accessible(self, client, monkeypatch):
+        monkeypatch.delenv("CI_AGENT_API_KEY", raising=False)
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+
+
+class TestAuthWithKeyConfigured:
+    """When CI_AGENT_API_KEY is set, /api/* endpoints require a valid Bearer token."""
+
+    API_KEY = "test-secret-key-12345"
+
+    @pytest.mark.asyncio
+    async def test_no_token_returns_401(self, client, monkeypatch):
+        monkeypatch.setenv("CI_AGENT_API_KEY", self.API_KEY)
+        resp = await client.get("/api/dashboard")
+        assert resp.status_code == 401
+        assert "Invalid or missing API key" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_returns_401(self, client, monkeypatch):
+        monkeypatch.setenv("CI_AGENT_API_KEY", self.API_KEY)
+        resp = await client.get(
+            "/api/dashboard",
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_correct_token_passes(self, client, monkeypatch):
+        monkeypatch.setenv("CI_AGENT_API_KEY", self.API_KEY)
+        resp = await client.get(
+            "/api/dashboard",
+            headers={"Authorization": f"Bearer {self.API_KEY}"},
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_health_always_exempt(self, client, monkeypatch):
+        monkeypatch.setenv("CI_AGENT_API_KEY", self.API_KEY)
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -15,18 +15,26 @@ const BASE_URL =
     ? (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000')
     : '';
 
+const API_KEY = process.env.NEXT_PUBLIC_CI_AGENT_API_KEY ?? '';
+
 async function request<T>(
   path: string,
   options?: RequestInit,
 ): Promise<T> {
   const url = `${BASE_URL}${path}`;
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options?.headers as Record<string, string> ?? {}),
+  };
+
+  if (API_KEY) {
+    headers['Authorization'] = `Bearer ${API_KEY}`;
+  }
+
   const res = await fetch(url, {
     cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(options?.headers ?? {}),
-    },
+    headers,
     ...options,
   });
 


### PR DESCRIPTION
## Summary
- 新增 `CI_AGENT_API_KEY` 环境变量支持静态 Bearer Token 认证
- 未配置时跳过认证（向后兼容本地开发）
- `/health`、`/docs`、`/openapi.json` 端点豁免认证
- 前端通过 `NEXT_PUBLIC_CI_AGENT_API_KEY` 自动附带 Authorization header
- 更新 `.env.example`、`docker-compose.yaml`、K8s Secret 配置

Closes #13

## Test plan
- [x] 6 个新增测试覆盖：无 key 放行、有 key 拦截、正确 key 通过、health 端点豁免
- [ ] 手动测试：设置 `CI_AGENT_API_KEY` 后验证 API 请求

🤖 Generated with [Claude Code](https://claude.com/claude-code)