### PR TITLE
feat: clone timeout handling and workflow file limit (#14)

### DIFF
--- a/src/ci_optimizer/prefetch.py
+++ b/src/ci_optimizer/prefetch.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 # Max number of runs to fetch job details for (to avoid rate limiting)
 MAX_RUNS_FOR_JOBS = 20
 
+# Max number of workflow files to process (to avoid excessive analysis time)
+MAX_WORKFLOW_FILES = 20
+
 from ci_optimizer.filters import AnalysisFilters
 from ci_optimizer.github_client import GitHubClient
 from ci_optimizer.resolver import ResolvedInput
@@ -316,6 +319,16 @@ async def prepare_context(
     workflows_dir = resolved.local_path / ".github" / "workflows"
     if workflows_dir.exists():
         ctx.workflow_files = sorted(p for p in workflows_dir.iterdir() if p.suffix in (".yml", ".yaml"))
+
+    if len(ctx.workflow_files) > MAX_WORKFLOW_FILES:
+        total = len(ctx.workflow_files)
+        logger.warning(
+            "Repository has %d workflow files, limiting to %d. "
+            "Some workflows will not be analyzed.",
+            total,
+            MAX_WORKFLOW_FILES,
+        )
+        ctx.workflow_files = ctx.workflow_files[:MAX_WORKFLOW_FILES]
 
     if not ctx.workflow_files:
         raise FileNotFoundError(

--- a/src/ci_optimizer/resolver.py
+++ b/src/ci_optimizer/resolver.py
@@ -1,6 +1,7 @@
 """Input resolver: detect local path vs GitHub URL and extract repo info."""
 
 import re
+import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -73,16 +74,29 @@ def detect_github_remote(local_path: Path) -> tuple[str, str] | None:
     return None
 
 
-def clone_repo(url: str) -> tuple[Path, str]:
+def clone_repo(url: str, timeout: int = 120) -> tuple[Path, str]:
     """Shallow clone a GitHub repo to a temp directory. Returns (path, temp_dir)."""
     temp_dir = tempfile.mkdtemp(prefix="ci-agent-")
-    subprocess.run(
-        ["git", "clone", "--depth=1", url, temp_dir],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=True,
-    )
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth=1", url, temp_dir],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise RuntimeError(
+            f"Repository clone timed out after {timeout}s. "
+            "The repository may be too large or the network is slow. "
+            "Try using a local path instead."
+        )
+    except subprocess.CalledProcessError as e:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise RuntimeError(
+            f"Failed to clone repository: {e.stderr or e.stdout or str(e)}"
+        )
     return Path(temp_dir), temp_dir
 
 

--- a/tests/test_resolver_timeout.py
+++ b/tests/test_resolver_timeout.py
@@ -1,0 +1,107 @@
+"""Tests for clone_repo error handling and workflow file limits."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ci_optimizer.prefetch import MAX_WORKFLOW_FILES, prepare_context
+from ci_optimizer.resolver import ResolvedInput, clone_repo
+
+
+class TestCloneRepoTimeout:
+    def test_timeout_raises_runtime_error(self):
+        with patch(
+            "ci_optimizer.resolver.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git clone", timeout=120),
+        ):
+            with pytest.raises(RuntimeError, match="clone timed out after 120s"):
+                clone_repo("https://github.com/owner/repo")
+
+    def test_timeout_cleans_up_temp_dir(self, tmp_path):
+        fake_temp = tmp_path / "ci-agent-test"
+        fake_temp.mkdir()
+
+        with (
+            patch("ci_optimizer.resolver.tempfile.mkdtemp", return_value=str(fake_temp)),
+            patch(
+                "ci_optimizer.resolver.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="git clone", timeout=120),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                clone_repo("https://github.com/owner/repo")
+
+        assert not fake_temp.exists()
+
+    def test_custom_timeout_value(self):
+        with patch(
+            "ci_optimizer.resolver.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git clone", timeout=30),
+        ):
+            with pytest.raises(RuntimeError, match="clone timed out after 30s"):
+                clone_repo("https://github.com/owner/repo", timeout=30)
+
+
+class TestCloneRepoFailure:
+    def test_called_process_error_raises_runtime_error(self):
+        with patch(
+            "ci_optimizer.resolver.subprocess.run",
+            side_effect=subprocess.CalledProcessError(
+                128, "git clone", stderr="fatal: repository not found"
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to clone repository"):
+                clone_repo("https://github.com/owner/repo")
+
+    def test_stderr_included_in_message(self):
+        with patch(
+            "ci_optimizer.resolver.subprocess.run",
+            side_effect=subprocess.CalledProcessError(
+                128, "git clone", stderr="fatal: repository not found"
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="repository not found"):
+                clone_repo("https://github.com/owner/repo")
+
+    def test_failure_cleans_up_temp_dir(self, tmp_path):
+        fake_temp = tmp_path / "ci-agent-test"
+        fake_temp.mkdir()
+
+        with (
+            patch("ci_optimizer.resolver.tempfile.mkdtemp", return_value=str(fake_temp)),
+            patch(
+                "ci_optimizer.resolver.subprocess.run",
+                side_effect=subprocess.CalledProcessError(128, "git clone", stderr="error"),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                clone_repo("https://github.com/owner/repo")
+
+        assert not fake_temp.exists()
+
+
+class TestWorkflowFileLimit:
+    @pytest.mark.asyncio
+    async def test_workflow_files_truncated_at_limit(self, tmp_path):
+        """Repos with more than MAX_WORKFLOW_FILES should be truncated."""
+        workflows_dir = tmp_path / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        # Create more workflow files than the limit
+        for i in range(MAX_WORKFLOW_FILES + 5):
+            (workflows_dir / f"wf-{i:03d}.yml").write_text(f"name: Workflow {i}\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+
+        resolved = ResolvedInput(local_path=tmp_path)
+        ctx = await prepare_context(resolved)
+
+        assert len(ctx.workflow_files) == MAX_WORKFLOW_FILES
+
+    @pytest.mark.asyncio
+    async def test_workflow_files_under_limit_unchanged(self, tmp_repo):
+        """Repos under the limit should keep all workflow files."""
+        resolved = ResolvedInput(local_path=tmp_repo)
+        ctx = await prepare_context(resolved)
+
+        assert len(ctx.workflow_files) == 2


### PR DESCRIPTION
## Summary
- `clone_repo()` 增加友好的超时错误提示，默认超时从 60s 提升至 120s
- clone 失败时自动清理临时目录
- `prepare_context()` 新增 `MAX_WORKFLOW_FILES=20` 限制，超过时截断并记录 warning
- 新增 8 个测试覆盖超时、失败、清理和截断逻辑

Closes #14

## Test plan
- [x] 3 个超时测试 + 3 个失败处理测试 + 2 个 workflow 文件限制测试
- [ ] 手动测试：分析大型仓库（如 kubernetes/kubernetes）验证超时提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)