### PR TITLE
feat: analysis result caching with configurable TTL (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,8 @@ GITHUB_TOKEN=your-github-token
 
 # Log level for the ci_optimizer namespace
 # CI_AGENT_LOG_LEVEL=INFO
+
+# ── Caching ──────────────────────────────────
+# Reuse completed reports for the same repo+filters within this window.
+# Set to 0 to disable caching entirely.
+# CI_AGENT_CACHE_TTL_HOURS=24

--- a/src/ci_optimizer/api/routes.py
+++ b/src/ci_optimizer/api/routes.py
@@ -1,6 +1,7 @@
 """FastAPI route handlers."""
 
 import json
+import os
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,8 +23,10 @@ from ci_optimizer.api.schemas import (  # noqa: E501 — many imports
 from ci_optimizer.config import AgentConfig
 from ci_optimizer.db.crud import (
     complete_report,
+    compute_filters_hash,
     create_report,
     fail_report,
+    find_cached_report,
     get_dashboard_stats,
     get_or_create_repo,
     get_report,
@@ -178,7 +181,15 @@ async def analyze(
     filters_json = json.dumps(filters.to_dict()) if filters else None
     config = _build_config_from_schema(request.agent_config)
 
-    report = await create_report(db, db_repo.id, filters_json)
+    # Check cache: reuse recent completed report for same repo+filters
+    fhash = compute_filters_hash(filters_json)
+    ttl = int(os.getenv("CI_AGENT_CACHE_TTL_HOURS", "24"))
+    if ttl > 0:
+        cached = await find_cached_report(db, db_repo.id, fhash, ttl)
+        if cached:
+            return {"report_id": cached.id, "status": "completed", "cached": True}
+
+    report = await create_report(db, db_repo.id, filters_json, filters_hash=fhash)
     await db.commit()
 
     background_tasks.add_task(_run_analysis_task, report.id, request.repo, filters, config, request.skills)

--- a/src/ci_optimizer/db/crud.py
+++ b/src/ci_optimizer/db/crud.py
@@ -1,12 +1,42 @@
 """CRUD operations for CI Agent database."""
 
-from datetime import datetime, timezone
+import hashlib
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ci_optimizer.db.models import AnalysisReport, Finding, Repository
+
+
+def compute_filters_hash(filters_json: str | None) -> str:
+    """Return a short deterministic hash for the given filters JSON string."""
+    content = filters_json or ""
+    return hashlib.md5(content.encode()).hexdigest()[:12]
+
+
+async def find_cached_report(
+    session: AsyncSession,
+    repo_id: int,
+    filters_hash: str,
+    ttl_hours: int = 24,
+) -> AnalysisReport | None:
+    """Return the most recent completed report matching the cache key within TTL."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=ttl_hours)
+    stmt = (
+        select(AnalysisReport)
+        .where(
+            AnalysisReport.repo_id == repo_id,
+            AnalysisReport.filters_hash == filters_hash,
+            AnalysisReport.status == "completed",
+            AnalysisReport.created_at >= cutoff,
+        )
+        .order_by(AnalysisReport.created_at.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
 
 
 async def get_or_create_repo(session: AsyncSession, owner: str, repo: str, url: str | None = None) -> Repository:
@@ -24,10 +54,12 @@ async def create_report(
     session: AsyncSession,
     repo_id: int,
     filters_json: str | None = None,
+    filters_hash: str | None = None,
 ) -> AnalysisReport:
     report = AnalysisReport(
         repo_id=repo_id,
         filters_json=filters_json,
+        filters_hash=filters_hash,
         status="running",
     )
     session.add(report)

--- a/src/ci_optimizer/db/database.py
+++ b/src/ci_optimizer/db/database.py
@@ -29,6 +29,7 @@ async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit
 # column exists), SQLite won't re-apply it thanks to the PRAGMA check.
 _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
     ("findings", "skill_name", "ALTER TABLE findings ADD COLUMN skill_name TEXT"),
+    ("analysis_reports", "filters_hash", "ALTER TABLE analysis_reports ADD COLUMN filters_hash TEXT"),
 ]
 
 

--- a/src/ci_optimizer/db/models.py
+++ b/src/ci_optimizer/db/models.py
@@ -31,6 +31,7 @@ class AnalysisReport(Base):
     repo_id: Mapped[int] = mapped_column(ForeignKey("repositories.id"))
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
     filters_json: Mapped[str | None] = mapped_column(Text)
+    filters_hash: Mapped[str | None] = mapped_column(index=True)
     status: Mapped[str] = mapped_column(default="pending")  # pending/running/completed/failed
     summary_md: Mapped[str | None] = mapped_column(Text)
     full_report_json: Mapped[str | None] = mapped_column(Text)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,124 @@
+"""Tests for analysis result caching."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ci_optimizer.db.crud import (
+    complete_report,
+    compute_filters_hash,
+    create_report,
+    find_cached_report,
+    get_or_create_repo,
+)
+
+
+class TestComputeFiltersHash:
+    def test_consistent_output(self):
+        h1 = compute_filters_hash('{"branches": ["main"]}')
+        h2 = compute_filters_hash('{"branches": ["main"]}')
+        assert h1 == h2
+
+    def test_different_for_different_filters(self):
+        h1 = compute_filters_hash('{"branches": ["main"]}')
+        h2 = compute_filters_hash('{"branches": ["dev"]}')
+        assert h1 != h2
+
+    def test_none_treated_as_empty(self):
+        h1 = compute_filters_hash(None)
+        h2 = compute_filters_hash("")
+        assert h1 == h2
+
+    def test_returns_short_hex(self):
+        h = compute_filters_hash("anything")
+        assert len(h) == 12
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestFindCachedReport:
+    @pytest.mark.asyncio
+    async def test_returns_cached_completed_report(self, db_session):
+        repo = await get_or_create_repo(db_session, "octocat", "hello-world")
+        fhash = compute_filters_hash(None)
+
+        report = await create_report(db_session, repo.id, filters_hash=fhash)
+        await complete_report(
+            db_session,
+            report.id,
+            summary_md="cached",
+            full_report_json="{}",
+            findings_data=[],
+            duration_ms=100,
+        )
+
+        cached = await find_cached_report(db_session, repo.id, fhash, ttl_hours=24)
+        assert cached is not None
+        assert cached.id == report.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_expired(self, db_session):
+        repo = await get_or_create_repo(db_session, "octocat", "hello-world")
+        fhash = compute_filters_hash(None)
+
+        report = await create_report(db_session, repo.id, filters_hash=fhash)
+        await complete_report(
+            db_session,
+            report.id,
+            summary_md="old",
+            full_report_json="{}",
+            findings_data=[],
+            duration_ms=100,
+        )
+
+        # Manually backdate created_at beyond the TTL
+        report.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        await db_session.flush()
+
+        cached = await find_cached_report(db_session, repo.id, fhash, ttl_hours=24)
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_running_report(self, db_session):
+        repo = await get_or_create_repo(db_session, "octocat", "hello-world")
+        fhash = compute_filters_hash(None)
+
+        # Report exists but is still running (not completed)
+        await create_report(db_session, repo.id, filters_hash=fhash)
+
+        cached = await find_cached_report(db_session, repo.id, fhash, ttl_hours=24)
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_different_hash(self, db_session):
+        repo = await get_or_create_repo(db_session, "octocat", "hello-world")
+        fhash = compute_filters_hash('{"branches": ["main"]}')
+
+        report = await create_report(db_session, repo.id, filters_hash=fhash)
+        await complete_report(
+            db_session,
+            report.id,
+            summary_md="done",
+            full_report_json="{}",
+            findings_data=[],
+            duration_ms=100,
+        )
+
+        other_hash = compute_filters_hash('{"branches": ["dev"]}')
+        cached = await find_cached_report(db_session, repo.id, other_hash, ttl_hours=24)
+        assert cached is None
+
+    @pytest.mark.asyncio
+    async def test_returns_most_recent(self, db_session):
+        repo = await get_or_create_repo(db_session, "octocat", "hello-world")
+        fhash = compute_filters_hash(None)
+
+        # Create two completed reports with same hash
+        r1 = await create_report(db_session, repo.id, filters_hash=fhash)
+        await complete_report(db_session, r1.id, "old", "{}", [], 100)
+
+        r2 = await create_report(db_session, repo.id, filters_hash=fhash)
+        await complete_report(db_session, r2.id, "new", "{}", [], 200)
+
+        cached = await find_cached_report(db_session, repo.id, fhash, ttl_hours=24)
+        assert cached is not None
+        assert cached.id == r2.id


### PR DESCRIPTION
## Summary
- 新增 `filters_hash` 列用于缓存查询（MD5 前 12 位）
- `analyze` 端点在创建新分析前查询缓存，命中则直接返回 `{"cached": true}`
- 通过 `CI_AGENT_CACHE_TTL_HOURS` 环境变量配置缓存有效期（默认 24h，设为 0 禁用）
- SQLite 自动迁移添加新列
- 新增 9 个测试覆盖 hash 一致性、TTL 过期、缓存命中等场景

Closes #15

## Test plan
- [x] 9 个新增测试全部通过
- [ ] 手动测试：同一仓库同条件二次分析应返回缓存结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)