### PR TITLE
ci: add Docker Compose smoke test, Trivy scan, and K8s validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,142 @@ jobs:
                 --summary
             fi
           done
+
+  k8s-smoke-test:
+    name: K8s Deployment Smoke Test
+    runs-on: ubuntu-latest
+    needs: [docker-build, k8s-validate]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kind
+        run: |
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 -o /usr/local/bin/kind
+          chmod +x /usr/local/bin/kind
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: v1.29.0
+
+      - name: Install kustomize
+        run: |
+          curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+          mv kustomize /usr/local/bin/
+
+      - name: Build Docker images
+        run: |
+          docker build -f Dockerfile.backend -t ci-agent-backend:ci .
+          docker build -f Dockerfile.frontend \
+            --build-arg NEXT_PUBLIC_API_URL=http://ci-agent-backend:8000 \
+            -t ci-agent-frontend:ci .
+
+      - name: Create kind cluster
+        run: kind create cluster --name ci-agent --wait 60s
+
+      - name: Load images into kind
+        run: |
+          kind load docker-image ci-agent-backend:ci --name ci-agent
+          kind load docker-image ci-agent-frontend:ci --name ci-agent
+
+      - name: Patch kustomization for CI images
+        run: |
+          # Create a CI-specific overlay on top of minikube overlay
+          WORKSPACE="${{ github.workspace }}"
+          mkdir -p /tmp/k8s-ci
+          cat > /tmp/k8s-ci/kustomization.yaml <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ci-agent
+resources:
+  - ${WORKSPACE}/deploy/k8s/overlays/minikube
+images:
+  - name: ci-agent-backend:v0.1.0
+    newName: ci-agent-backend
+    newTag: ci
+  - name: ci-agent-frontend:v0.1.0
+    newName: ci-agent-frontend
+    newTag: ci
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: ci-agent-secrets
+        namespace: ci-agent
+      stringData:
+        ANTHROPIC_API_KEY: "sk-ant-test-placeholder"
+        GITHUB_TOKEN: "placeholder"
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ci-agent-config
+        namespace: ci-agent
+      data:
+        CORS_ORIGINS: "http://localhost:3000"
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: ci-agent-frontend
+EOF
+
+      - name: Deploy to kind
+        run: |
+          kustomize build /tmp/k8s-ci | kubectl apply -f -
+
+      - name: Wait for deployments ready
+        run: |
+          kubectl rollout status deployment/ci-agent-backend -n ci-agent --timeout=120s
+          kubectl rollout status deployment/ci-agent-frontend -n ci-agent --timeout=120s
+
+      - name: Verify backend health via port-forward
+        run: |
+          kubectl port-forward svc/ci-agent-backend 18000:8000 -n ci-agent &
+          PF_PID=$!
+          sleep 5
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:18000/health; then
+              echo "Backend healthy"
+              break
+            fi
+            echo "Waiting... ($i/20)"
+            sleep 3
+          done
+          curl -sf http://localhost:18000/health | grep '"status":"ok"'
+          curl -sf http://localhost:18000/api/dashboard | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); assert 'repo_count' in d"
+          curl -sf http://localhost:18000/api/skills | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); assert isinstance(d, list)"
+          kill $PF_PID
+
+      - name: Verify frontend via port-forward
+        run: |
+          kubectl port-forward svc/ci-agent-frontend 13000:3000 -n ci-agent &
+          PF_PID=$!
+          sleep 5
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:13000/ > /dev/null; then
+              echo "Frontend healthy"
+              break
+            fi
+            echo "Waiting... ($i/20)"
+            sleep 3
+          done
+          curl -sf -o /dev/null -w "%{http_code}" http://localhost:13000/ | grep -E "^(200|304)$"
+          kill $PF_PID
+
+      - name: Show pod status on failure
+        if: failure()
+        run: |
+          kubectl get pods -n ci-agent -o wide
+          kubectl describe pods -n ci-agent
+          kubectl logs -n ci-agent -l app.kubernetes.io/name=backend --tail=100 || true
+          kubectl logs -n ci-agent -l app.kubernetes.io/name=frontend --tail=50 || true
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name ci-agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,120 @@ jobs:
           docker build -f Dockerfile.frontend \
             --build-arg NEXT_PUBLIC_API_URL=http://ci-agent-backend:8000 \
             -t ci-agent-frontend:ci .
+
+  docker-smoke-test:
+    name: Docker Compose Smoke Test
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build images
+        run: |
+          docker build -f Dockerfile.backend -t ci-agent-backend:ci .
+          docker build -f Dockerfile.frontend \
+            --build-arg NEXT_PUBLIC_API_URL=http://backend:8000 \
+            -t ci-agent-frontend:ci .
+      - name: Override image tags in compose
+        run: |
+          cat > docker-compose.ci.yml <<'EOF'
+          services:
+            backend:
+              image: ci-agent-backend:ci
+              build: null
+            frontend:
+              image: ci-agent-frontend:ci
+              build: null
+          EOF
+      - name: Start services
+        run: |
+          ANTHROPIC_API_KEY=sk-ant-test-placeholder \
+          GITHUB_TOKEN=placeholder \
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yml up -d --no-build
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health; then
+              echo "Backend healthy"
+              exit 0
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 3
+          done
+          echo "Backend failed to become healthy"
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yml logs
+          exit 1
+      - name: Wait for frontend health
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:3000/ > /dev/null; then
+              echo "Frontend healthy"
+              exit 0
+            fi
+            echo "Waiting... ($i/20)"
+            sleep 3
+          done
+          echo "Frontend failed to become healthy"
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yml logs
+          exit 1
+      - name: Verify API endpoints
+        run: |
+          curl -sf http://localhost:8000/health | grep '"status":"ok"'
+          curl -sf http://localhost:8000/api/skills | python3 -c "import sys,json; data=json.load(sys.stdin); assert isinstance(data, list), 'skills endpoint should return a list'"
+          curl -sf http://localhost:8000/api/dashboard | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'repo_count' in data, 'dashboard should have repo_count'"
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yaml -f docker-compose.ci.yml logs
+      - name: Teardown
+        if: always()
+        run: docker compose -f docker-compose.yaml -f docker-compose.ci.yml down -v
+
+  docker-security-scan:
+    name: Docker Security Scan
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build backend image
+        run: docker build -f Dockerfile.backend -t ci-agent-backend:ci .
+      - name: Run Trivy scan on backend image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ci-agent-backend:ci
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: CRITICAL
+
+  # ── Kubernetes ───────────────────────────────────────────────
+  k8s-validate:
+    name: K8s Manifest Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kubeconform
+      - name: Install kustomize
+        run: |
+          curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+          mv kustomize /usr/local/bin/
+      - name: Validate base manifests
+        run: |
+          kustomize build deploy/k8s/ | kubeconform \
+            --strict \
+            --ignore-missing-schemas \
+            --kubernetes-version 1.29.0 \
+            --summary
+      - name: Validate overlays (if any)
+        run: |
+          for overlay in deploy/k8s/overlays/*/; do
+            if [ -d "$overlay" ]; then
+              echo "Validating overlay: $overlay"
+              kustomize build "$overlay" | kubeconform \
+                --strict \
+                --ignore-missing-schemas \
+                --kubernetes-version 1.29.0 \
+                --summary
+            fi
+          done


### PR DESCRIPTION
## Summary

在现有 CI（Lint + Test + Docker Build）基础上新增三个 job：

### 1. Docker Compose Smoke Test
- 构建 backend/frontend 镜像后，通过 `docker compose up` 启动完整服务栈
- 轮询等待 backend（`/health`）和 frontend（port 3000）就绪
- 验证关键 API 端点：`/health`、`/api/skills`、`/api/dashboard` 均正常响应
- 失败时自动 dump 容器日志，无论成功与否均执行 `down -v` 清理

### 2. Docker Security Scan (Trivy)
- 使用 `aquasecurity/trivy-action` 扫描 backend 镜像
- 仅在存在**有修复版本的 CRITICAL 漏洞**时 fail（`ignore-unfixed: true`）
- 输出 table 格式报告，便于 review

### 3. K8s Manifest Validation (kubeconform)
- 安装 kubeconform + kustomize
- `kustomize build deploy/k8s/` 生成完整 YAML，通过 kubeconform 校验合法性
- 同时校验所有 overlays（当前有 `minikube` overlay）
- 基于 Kubernetes 1.29.0 schema，`--ignore-missing-schemas` 跳过 CRD

## CI 依赖关系

```
backend-lint → backend-test ─┐
                              ├→ docker-build → docker-smoke-test
frontend-lint → frontend-build┘              └→ docker-security-scan

k8s-validate（独立运行，无需等待构建）
```

## Test plan
- [ ] 验证 Docker Compose Smoke Test 能正常启动服务并通过健康检查
- [ ] 验证 Trivy 扫描能输出报告
- [ ] 验证 K8s manifest 通过 kubeconform 校验

🤖 Generated with [Claude Code](https://claude.com/claude-code)