### PR TITLE
feat: Web UI Settings page + Chat E2E tests

### DIFF
--- a/src/ci_optimizer/api/routes.py
+++ b/src/ci_optimizer/api/routes.py
@@ -317,14 +317,29 @@ async def get_config():
     return config.to_display_dict()
 
 
+# Mapping: config field → env var name (so PUT /api/config can override env vars in-process)
+_FIELD_TO_ENV = {
+    "provider": "CI_AGENT_PROVIDER",
+    "model": "CI_AGENT_MODEL",
+    "anthropic_api_key": "ANTHROPIC_API_KEY",
+    "openai_api_key": "OPENAI_API_KEY",
+    "github_token": "GITHUB_TOKEN",
+    "base_url": "CI_AGENT_BASE_URL",
+    "language": "CI_AGENT_LANGUAGE",
+}
+
+
 @router.put("/config")
 async def update_config(updates: AgentConfigSchema):
-    """Update agent configuration."""
+    """Update agent configuration. Writes to config.json AND sets env vars in-process."""
     config = AgentConfig.load()
     for field in ("provider", "model", "fallback_model", "anthropic_api_key", "openai_api_key", "github_token", "base_url", "language"):
         val = getattr(updates, field, None)
         if val is not None:
             setattr(config, field, val)
+            # Also set env var so load() won't revert the change
+            if env_key := _FIELD_TO_ENV.get(field):
+                os.environ[env_key] = val
     if updates.max_turns is not None:
         config.max_turns = updates.max_turns
     config.save()

--- a/tests/test_chat_e2e.py
+++ b/tests/test_chat_e2e.py
@@ -1,0 +1,242 @@
+"""E2E tests for /api/chat SSE endpoint.
+
+Tests the full HTTP flow: FastAPI → SSE streaming → agentic tool loop → events.
+LLM is mocked at the SDK level; everything else (routing, auth, tools) is real.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ci_optimizer.api.app import app
+
+
+def _parse_sse(body: str) -> list[tuple[str, dict]]:
+    """Parse SSE text into a list of (event_type, data) tuples."""
+    events = []
+    event_type = None
+    for line in body.splitlines():
+        line = line.strip()
+        if line.startswith("event: "):
+            event_type = line[7:]
+        elif line.startswith("data: ") and event_type:
+            events.append((event_type, json.loads(line[6:])))
+            event_type = None
+    return events
+
+
+def _make_text_response(text: str, model: str = "test-model"):
+    """Create a mock Anthropic response with a text block."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+
+    resp = MagicMock()
+    resp.stop_reason = "end_turn"
+    resp.content = [block]
+    resp.usage = MagicMock(input_tokens=100, output_tokens=50)
+    resp.model = model
+    return resp
+
+
+def _make_tool_response(tool_name: str, tool_input: dict, model: str = "test-model"):
+    """Create a mock Anthropic response with a tool_use block."""
+    block = MagicMock()
+    block.type = "tool_use"
+    block.id = f"call_{tool_name}"
+    block.name = tool_name
+    block.input = tool_input
+
+    resp = MagicMock()
+    resp.stop_reason = "tool_use"
+    resp.content = [block]
+    resp.usage = MagicMock(input_tokens=100, output_tokens=50)
+    resp.model = model
+    return resp
+
+
+@pytest.fixture
+def repo_with_workflow(tmp_path):
+    """Create a minimal repo with a workflow file."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "ci.yml").write_text("name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest")
+    return tmp_path
+
+
+class TestChatE2E:
+    """End-to-end tests for /api/chat SSE endpoint."""
+
+    @patch("ci_optimizer.api.chat._query_anthropic")
+    async def test_simple_text_response(self, mock_query):
+        """A simple text-only response returns text + done SSE events."""
+
+        async def _fake_stream(*args, **kwargs):
+            yield 'event: text\ndata: {"content": "Hello!"}\n\n'
+            yield 'event: done\ndata: {"usage": {"input_tokens": 10, "output_tokens": 5}, "model": "test", "turns": 1}\n\n'
+
+        mock_query.return_value = _fake_stream()
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "repo": "test/repo",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+        assert "text" in event_types
+        assert "done" in event_types
+
+    @patch("ci_optimizer.api.chat.AgentConfig")
+    async def test_anthropic_tool_use_flow(self, mock_config_cls, repo_with_workflow):
+        """Anthropic provider: tool calling works end-to-end via SSE."""
+        config = MagicMock()
+        config.provider = "anthropic"
+        config.model = "test-model"
+        config.anthropic_api_key = "test-key"
+        config.anthropic_base_url = None
+        config.max_turns = 10
+        config.get_sdk_env.return_value = {}
+        mock_config_cls.load.return_value = config
+
+        first_resp = _make_tool_response("list_workflows", {})
+        second_resp = _make_text_response("Found 1 workflow: ci.yml")
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[first_resp, second_resp])
+
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/chat",
+                    json={
+                        "messages": [{"role": "user", "content": "list workflows"}],
+                        "repo": "test/repo",
+                        "repo_root": str(repo_with_workflow),
+                    },
+                )
+
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+
+        assert "tool_use" in event_types, f"Expected tool_use, got: {event_types}"
+        assert "tool_result" in event_types, f"Expected tool_result, got: {event_types}"
+        assert "done" in event_types
+
+        # Verify tool_result contains workflow file info
+        tool_results = [e[1] for e in events if e[0] == "tool_result"]
+        assert any("ci.yml" in r.get("result_preview", "") for r in tool_results)
+
+    @patch("ci_optimizer.api.chat.AgentConfig")
+    async def test_openai_tool_use_flow(self, mock_config_cls, repo_with_workflow):
+        """OpenAI provider: tool calling works end-to-end via SSE."""
+        config = MagicMock()
+        config.provider = "openai"
+        config.model = "gpt-test"
+        config.openai_api_key = "test-key"
+        config.base_url = "http://fake"
+        config.max_turns = 10
+        mock_config_cls.load.return_value = config
+
+        # First response: tool call
+        tool_call = MagicMock()
+        tool_call.id = "call_1"
+        tool_call.function.name = "list_workflows"
+        tool_call.function.arguments = "{}"
+
+        first_msg = MagicMock()
+        first_msg.content = None
+        first_msg.tool_calls = [tool_call]
+        first_msg.model_dump.return_value = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "list_workflows",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        }
+
+        first_choice = MagicMock()
+        first_choice.message = first_msg
+        first_choice.finish_reason = "tool_calls"
+
+        first_resp = MagicMock()
+        first_resp.choices = [first_choice]
+        first_resp.usage = MagicMock(total_tokens=100)
+
+        # Second response: text
+        second_msg = MagicMock()
+        second_msg.content = "Found 1 workflow."
+        second_msg.tool_calls = None
+
+        second_choice = MagicMock()
+        second_choice.message = second_msg
+        second_choice.finish_reason = "stop"
+
+        second_resp = MagicMock()
+        second_resp.choices = [second_choice]
+        second_resp.usage = MagicMock(total_tokens=150)
+
+        with patch("openai.AsyncOpenAI") as mock_openai_cls:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(side_effect=[first_resp, second_resp])
+            mock_openai_cls.return_value = mock_client
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/chat",
+                    json={
+                        "messages": [{"role": "user", "content": "list workflows"}],
+                        "repo": "test/repo",
+                        "repo_root": str(repo_with_workflow),
+                    },
+                )
+
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+
+        assert "tool_use" in event_types, f"Expected tool_use, got: {event_types}"
+        assert "tool_result" in event_types, f"Expected tool_result, got: {event_types}"
+        assert "done" in event_types
+
+    @patch("ci_optimizer.api.chat._query_anthropic")
+    async def test_error_returns_error_event(self, mock_query):
+        """When the LLM call fails, an error SSE event is returned."""
+
+        async def _fail(*args, **kwargs):
+            raise RuntimeError("LLM unavailable")
+            yield  # noqa: unreachable — makes this an async generator
+
+        mock_query.side_effect = _fail
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/chat",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+        assert resp.status_code == 200  # SSE always returns 200, errors in stream
+        events = _parse_sse(resp.text)
+        error_events = [e for e in events if e[0] == "error"]
+        assert len(error_events) >= 1
+        assert "LLM unavailable" in error_events[0][1].get("message", "")

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { getWebhookStatus } from '@/lib/api';
+import { getAgentConfig, getWebhookStatus, updateAgentConfig } from '@/lib/api';
 import { useLocale } from '@/lib/locale';
 import type { WebhookStatus } from '@/types';
+
+/* ── Shared UI helpers ─────────────────────────────────────────────────── */
 
 function CopyButton({ text }: { text: string }) {
   const { t } = useLocale();
@@ -33,7 +35,226 @@ function StatusDot({ ok }: { ok: boolean }) {
   );
 }
 
-export default function SettingsPage() {
+/* ── Agent Config Card ─────────────────────────────────────────────────── */
+
+interface ConfigField {
+  key: string;
+  label: string;
+  type: 'text' | 'select' | 'password';
+  options?: string[];
+  placeholder?: string;
+  help?: string;
+}
+
+const CONFIG_FIELDS: ConfigField[] = [
+  {
+    key: 'provider',
+    label: 'AI Provider',
+    type: 'select',
+    options: ['anthropic', 'openai'],
+    help: 'Choose between Anthropic (Claude) or OpenAI (GPT) models',
+  },
+  {
+    key: 'model',
+    label: 'Model',
+    type: 'text',
+    placeholder: 'e.g. claude-sonnet-4-20250514 or gpt-4o',
+    help: 'Model name used for analysis and chat',
+  },
+  {
+    key: 'anthropic_api_key',
+    label: 'Anthropic API Key',
+    type: 'password',
+    placeholder: 'sk-ant-...',
+    help: 'Required when provider is anthropic',
+  },
+  {
+    key: 'openai_api_key',
+    label: 'OpenAI API Key',
+    type: 'password',
+    placeholder: 'sk-...',
+    help: 'Required when provider is openai',
+  },
+  {
+    key: 'base_url',
+    label: 'API Base URL',
+    type: 'text',
+    placeholder: 'Leave empty for official API',
+    help: 'Custom endpoint for OpenAI-compatible proxies',
+  },
+  {
+    key: 'github_token',
+    label: 'GitHub Token',
+    type: 'password',
+    placeholder: 'ghp_...',
+    help: 'Required for fetching CI run history (5000 req/hr vs 60 without)',
+  },
+  {
+    key: 'language',
+    label: 'Language',
+    type: 'select',
+    options: ['en', 'zh'],
+    help: 'Report and TUI output language',
+  },
+];
+
+function AgentConfigCard() {
+  const [config, setConfig] = useState<Record<string, string>>({});
+  const [editValues, setEditValues] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getAgentConfig();
+        const stringData: Record<string, string> = {};
+        for (const [k, v] of Object.entries(data)) {
+          stringData[k] = String(v ?? '');
+        }
+        setConfig(stringData);
+        setEditValues(stringData);
+      } catch {
+        setMessage({ type: 'error', text: 'Failed to load config' });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+
+    // Only send fields that changed and are non-empty
+    const updates: Record<string, string> = {};
+    for (const field of CONFIG_FIELDS) {
+      const newVal = editValues[field.key] ?? '';
+      const oldVal = config[field.key] ?? '';
+      // Skip masked values (e.g. "sk-ant-a1...xyz9") unless user typed a new key
+      if (newVal !== oldVal && !newVal.includes('...')) {
+        updates[field.key] = newVal;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      setMessage({ type: 'success', text: 'No changes to save' });
+      setSaving(false);
+      return;
+    }
+
+    try {
+      const updated = await updateAgentConfig(updates);
+      const stringData: Record<string, string> = {};
+      for (const [k, v] of Object.entries(updated)) {
+        stringData[k] = String(v ?? '');
+      }
+      setConfig(stringData);
+      setEditValues(stringData);
+      setMessage({ type: 'success', text: 'Configuration saved' });
+    } catch (e) {
+      setMessage({ type: 'error', text: e instanceof Error ? e.message : 'Failed to save' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card">
+        <div className="flex items-center justify-center py-8 text-slate-400">
+          <svg className="animate-spin h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Loading configuration...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card space-y-5">
+      <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-blue">
+          <path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" stroke="currentColor" strokeWidth="2"/>
+          <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2"/>
+        </svg>
+        Agent Configuration
+      </h2>
+
+      <div className="space-y-4">
+        {CONFIG_FIELDS.map((field) => (
+          <div key={field.key} className="space-y-1">
+            <label className="block text-sm font-medium text-slate-300">
+              {field.label}
+            </label>
+            {field.type === 'select' ? (
+              <select
+                value={editValues[field.key] ?? ''}
+                onChange={(e) =>
+                  setEditValues((prev) => ({ ...prev, [field.key]: e.target.value }))
+                }
+                className="w-full bg-surface-elevated border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-accent-blue"
+              >
+                {field.options?.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type={field.type}
+                value={editValues[field.key] ?? ''}
+                onChange={(e) =>
+                  setEditValues((prev) => ({ ...prev, [field.key]: e.target.value }))
+                }
+                placeholder={field.placeholder}
+                className="w-full bg-surface-elevated border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-accent-blue font-mono"
+              />
+            )}
+            {field.help && (
+              <p className="text-xs text-slate-500">{field.help}</p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Save button + message */}
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 bg-accent-blue text-white text-sm font-medium rounded-lg hover:bg-accent-blue/80 disabled:opacity-50 transition-colors"
+        >
+          {saving ? 'Saving...' : 'Save Configuration'}
+        </button>
+        {message && (
+          <span className={`text-sm ${message.type === 'success' ? 'text-green-400' : 'text-red-400'}`}>
+            {message.text}
+          </span>
+        )}
+      </div>
+
+      {/* Priority note */}
+      <div className="bg-surface-elevated rounded-lg p-4 text-xs text-slate-500 space-y-1">
+        <p className="font-medium text-slate-400">Configuration Priority (high → low):</p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li><span className="text-slate-400">This page / API</span> — takes effect immediately and persists to <code className="text-slate-400">~/.ci-agent/config.json</code></li>
+          <li><span className="text-slate-400">Environment variables / .env</span> — used at startup as initial values</li>
+          <li><span className="text-slate-400">Default values</span> — built-in defaults</li>
+        </ol>
+        <p className="mt-1">Changes made here override environment variables for the running server. After a server restart, <code className="text-slate-400">.env</code> and <code className="text-slate-400">config.json</code> are both loaded (env vars win if both set the same field).</p>
+      </div>
+    </div>
+  );
+}
+
+/* ── Webhook Config Card (original) ────────────────────────────────────── */
+
+function WebhookConfigCard() {
   const { t } = useLocale();
   const [status, setStatus] = useState<WebhookStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -70,145 +291,157 @@ curl -X POST ${status.webhook_url} \\
   -d "$BODY"`
     : '';
 
-  return (
-    <div className="space-y-8">
-      {/* Page heading */}
-      <div>
-        <h1 className="text-2xl font-bold text-white">{t('settings.title')}</h1>
-        <p className="text-slate-400 text-sm mt-1">{t('settings.subtitle')}</p>
-      </div>
-
-      {loading && (
-        <div className="flex items-center justify-center py-12 text-slate-400">
+  if (loading) {
+    return (
+      <div className="card">
+        <div className="flex items-center justify-center py-8 text-slate-400">
           <svg className="animate-spin h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
           Loading...
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {error && (
-        <div className="card border border-red-500/20 bg-red-500/5 text-red-400 text-sm">
-          {error}
+  if (error) {
+    return (
+      <div className="card border border-red-500/20 bg-red-500/5 text-red-400 text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!status) return null;
+
+  return (
+    <>
+      {/* Webhook status card */}
+      <div className="card space-y-5">
+        <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-blue">
+            <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          {t('webhook.title')}
+        </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="bg-surface-elevated rounded-lg p-4">
+            <p className="text-xs text-slate-500 mb-1">{t('webhook.status')}</p>
+            <p className="text-sm text-slate-200 flex items-center gap-2">
+              <StatusDot ok={status.enabled} />
+              {status.enabled ? t('webhook.enabled') : t('webhook.disabled')}
+            </p>
+          </div>
+
+          <div className="bg-surface-elevated rounded-lg p-4">
+            <p className="text-xs text-slate-500 mb-1">{t('webhook.secret')}</p>
+            <p className="text-sm flex items-center gap-2">
+              <StatusDot ok={status.secret_configured} />
+              <span className={status.secret_configured ? 'text-green-400' : 'text-yellow-400'}>
+                {status.secret_configured
+                  ? t('webhook.secret_configured')
+                  : t('webhook.secret_not_configured')}
+              </span>
+            </p>
+          </div>
+
+          <div className="bg-surface-elevated rounded-lg p-4 sm:col-span-2">
+            <p className="text-xs text-slate-500 mb-1">{t('webhook.url')}</p>
+            <div className="flex items-center gap-2">
+              <code className="text-sm text-accent-blue font-mono flex-1 break-all">
+                {status.webhook_url}
+              </code>
+              <CopyButton text={status.webhook_url} />
+            </div>
+          </div>
+
+          <div className="bg-surface-elevated rounded-lg p-4 sm:col-span-2">
+            <p className="text-xs text-slate-500 mb-1">{t('webhook.events')}</p>
+            <div className="flex gap-2 mt-1">
+              {status.supported_events.map((evt) => (
+                <span
+                  key={evt}
+                  className="px-2 py-0.5 text-xs rounded bg-accent-blue/15 text-accent-blue font-mono"
+                >
+                  {evt}
+                </span>
+              ))}
+            </div>
+          </div>
         </div>
-      )}
+      </div>
 
-      {!loading && !error && status && (
-        <>
-          {/* Webhook status card */}
-          <div className="card space-y-5">
-            <h2 className="text-lg font-semibold text-white flex items-center gap-2">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-blue">
-                <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-              {t('webhook.title')}
-            </h2>
+      {/* GitHub setup guide */}
+      <div className="card space-y-4">
+        <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-purple">
+            <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.607.069-.607 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" fill="currentColor"/>
+          </svg>
+          {t('webhook.setup_title')}
+        </h2>
+        <ol className="space-y-2 text-sm text-slate-300">
+          <li>{t('webhook.setup_step1')}</li>
+          <li>{t('webhook.setup_step2')}</li>
+          <li>{t('webhook.setup_step3')}</li>
+          <li>{t('webhook.setup_step4')}</li>
+          <li>{t('webhook.setup_step5')}</li>
+        </ol>
+      </div>
 
-            {/* Status grid */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Enabled */}
-              <div className="bg-surface-elevated rounded-lg p-4">
-                <p className="text-xs text-slate-500 mb-1">{t('webhook.status')}</p>
-                <p className="text-sm text-slate-200 flex items-center gap-2">
-                  <StatusDot ok={status.enabled} />
-                  {status.enabled ? t('webhook.enabled') : t('webhook.disabled')}
-                </p>
-              </div>
+      {/* curl examples */}
+      <div className="card space-y-4">
+        <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-green">
+            <polyline points="4 17 10 11 4 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <line x1="12" y1="19" x2="20" y2="19" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+          {t('webhook.curl_title')}
+        </h2>
 
-              {/* Secret */}
-              <div className="bg-surface-elevated rounded-lg p-4">
-                <p className="text-xs text-slate-500 mb-1">{t('webhook.secret')}</p>
-                <p className="text-sm flex items-center gap-2">
-                  <StatusDot ok={status.secret_configured} />
-                  <span className={status.secret_configured ? 'text-green-400' : 'text-yellow-400'}>
-                    {status.secret_configured
-                      ? t('webhook.secret_configured')
-                      : t('webhook.secret_not_configured')}
-                  </span>
-                </p>
-              </div>
+        <div className="relative">
+          <div className="absolute top-2 right-2">
+            <CopyButton text={curlExample} />
+          </div>
+          <pre className="bg-surface-elevated rounded-lg p-4 text-sm text-slate-300 font-mono overflow-x-auto">
+            {curlExample}
+          </pre>
+        </div>
 
-              {/* URL */}
-              <div className="bg-surface-elevated rounded-lg p-4 sm:col-span-2">
-                <p className="text-xs text-slate-500 mb-1">{t('webhook.url')}</p>
-                <div className="flex items-center gap-2">
-                  <code className="text-sm text-accent-blue font-mono flex-1 break-all">
-                    {status.webhook_url}
-                  </code>
-                  <CopyButton text={status.webhook_url} />
-                </div>
-              </div>
-
-              {/* Events */}
-              <div className="bg-surface-elevated rounded-lg p-4 sm:col-span-2">
-                <p className="text-xs text-slate-500 mb-1">{t('webhook.events')}</p>
-                <div className="flex gap-2 mt-1">
-                  {status.supported_events.map((evt) => (
-                    <span
-                      key={evt}
-                      className="px-2 py-0.5 text-xs rounded bg-accent-blue/15 text-accent-blue font-mono"
-                    >
-                      {evt}
-                    </span>
-                  ))}
-                </div>
-              </div>
+        {status.secret_configured && (
+          <div className="relative">
+            <div className="absolute top-2 right-2">
+              <CopyButton text={curlWithSignature} />
             </div>
+            <pre className="bg-surface-elevated rounded-lg p-4 text-sm text-slate-300 font-mono overflow-x-auto">
+              {curlWithSignature}
+            </pre>
           </div>
+        )}
+      </div>
+    </>
+  );
+}
 
-          {/* GitHub setup guide */}
-          <div className="card space-y-4">
-            <h2 className="text-lg font-semibold text-white flex items-center gap-2">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-purple">
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.607.069-.607 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" fill="currentColor"/>
-              </svg>
-              {t('webhook.setup_title')}
-            </h2>
-            <ol className="space-y-2 text-sm text-slate-300">
-              <li>{t('webhook.setup_step1')}</li>
-              <li>{t('webhook.setup_step2')}</li>
-              <li>{t('webhook.setup_step3')}</li>
-              <li>{t('webhook.setup_step4')}</li>
-              <li>{t('webhook.setup_step5')}</li>
-            </ol>
-          </div>
+/* ── Page ───────────────────────────────────────────────────────────────── */
 
-          {/* curl examples */}
-          <div className="card space-y-4">
-            <h2 className="text-lg font-semibold text-white flex items-center gap-2">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent-green">
-                <polyline points="4 17 10 11 4 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                <line x1="12" y1="19" x2="20" y2="19" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
-              {t('webhook.curl_title')}
-            </h2>
+export default function SettingsPage() {
+  const { t } = useLocale();
 
-            {/* Simple curl */}
-            <div className="relative">
-              <div className="absolute top-2 right-2">
-                <CopyButton text={curlExample} />
-              </div>
-              <pre className="bg-surface-elevated rounded-lg p-4 text-sm text-slate-300 font-mono overflow-x-auto">
-                {curlExample}
-              </pre>
-            </div>
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white">{t('settings.title')}</h1>
+        <p className="text-slate-400 text-sm mt-1">{t('settings.subtitle')}</p>
+      </div>
 
-            {/* With signature */}
-            {status.secret_configured && (
-              <div className="relative">
-                <div className="absolute top-2 right-2">
-                  <CopyButton text={curlWithSignature} />
-                </div>
-                <pre className="bg-surface-elevated rounded-lg p-4 text-sm text-slate-300 font-mono overflow-x-auto">
-                  {curlWithSignature}
-                </pre>
-              </div>
-            )}
-          </div>
-        </>
-      )}
+      {/* Agent config — provider, model, API keys, language */}
+      <AgentConfigCard />
+
+      {/* Webhook config — URL, secret, events, setup guide */}
+      <WebhookConfigCard />
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -161,6 +161,25 @@ export async function deleteSkill(name: string): Promise<{ removed: string }> {
 }
 
 /**
+ * Fetch agent configuration (sensitive values masked).
+ */
+export async function getAgentConfig(): Promise<Record<string, unknown>> {
+  return request<Record<string, unknown>>('/api/config');
+}
+
+/**
+ * Update agent configuration.
+ */
+export async function updateAgentConfig(
+  updates: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return request<Record<string, unknown>>('/api/config', {
+    method: 'PUT',
+    body: JSON.stringify(updates),
+  });
+}
+
+/**
  * Fetch webhook configuration status.
  */
 export async function getWebhookStatus(): Promise<WebhookStatus> {


### PR DESCRIPTION
## Summary

- **Agent Configuration page** (`/settings`): Web UI form to configure provider, model, API keys, GitHub token, base URL, language — writes to `~/.ci-agent/config.json` and sets env vars in-process for immediate effect
- **PUT /api/config env override**: API now sets process-level env vars so changes take effect immediately without server restart
- **Chat E2E tests**: 4 end-to-end tests for `/api/chat` SSE endpoint covering Anthropic tool-use flow, OpenAI function calling flow, text-only response, and error propagation
- **Configuration priority note**: Settings page shows priority explanation (API > env vars > config.json > defaults)

## Files Changed

| Area | Files |
|------|-------|
| Web UI | `web/src/app/settings/page.tsx`, `web/src/lib/api.ts` |
| Backend | `src/ci_optimizer/api/routes.py` |
| Tests | `tests/test_chat_e2e.py` |

## Test plan

- [ ] `uv run pytest tests/test_chat_e2e.py -v` — 4 E2E tests pass
- [ ] Open `http://localhost:3000/settings` — Agent Configuration card visible with form fields
- [ ] Change a config value → Save → verify change persists after page reload
- [ ] Verify env var override: set value via Web UI, confirm `GET /api/config` reflects new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)