### PR TITLE
docs: 为全部 39 个 Python 模块添加中文注解

### DIFF
--- a/src/ci_optimizer/__init__.py
+++ b/src/ci_optimizer/__init__.py
@@ -1,3 +1,11 @@
 """CI Agent - AI-powered GitHub CI pipeline analyzer and optimizer."""
+# ci_optimizer 是整个项目的顶级包，主要子包结构：
+#   tui/        — 交互式终端界面（入口：tui.app.run_tui）
+#   api/        — FastAPI 后端（SSE /api/chat、/api/chat/apply、/health 等接口）
+#   agents/     — 分析编排层（orchestrator、skill_registry、各维度 agent）
+#   report/     — 报告格式化（Markdown / JSON 输出）
+#   config.py   — AgentConfig 持久化配置（~/.ci-agent/config.json）
+#   prefetch.py — AnalysisContext 构建（拉取 workflow 文件、CI 数据）
+#   resolver.py — GitHub remote URL 解析（owner/repo 提取）
 
 __version__ = "0.1.0"

--- a/src/ci_optimizer/agents/__init__.py
+++ b/src/ci_optimizer/agents/__init__.py
@@ -1,0 +1,13 @@
+"""ci_optimizer.agents — agents 层包入口。
+
+本包包含 CI 分析系统的所有 agent 相关模块：
+
+  orchestrator    : 顶层调度器，将分析请求路由到 Anthropic 或 OpenAI 引擎
+  skill_registry  : 技能注册与管理，从 SKILL.md 文件加载 specialist 定义
+  anthropic_engine: 基于 Claude Agent SDK 的并行多专家执行引擎
+  openai_engine   : 基于 OpenAI Chat Completions API 的两阶段执行引擎
+  failure_triage  : 独立的 CI 故障诊断技能执行器（standalone skill）
+  prompts         : 共享的语言指令和输出格式常量
+  skill_importer  : 从外部系统（Claude Code、OpenCode、GitHub）导入技能
+  tracing         : Langfuse 可观测性集成（可选，未配置时自动禁用）
+"""

--- a/src/ci_optimizer/agents/anthropic_engine.py
+++ b/src/ci_optimizer/agents/anthropic_engine.py
@@ -1,4 +1,13 @@
-"""Anthropic engine — runs analysis via Claude Agent SDK."""
+"""Anthropic engine — runs analysis via Claude Agent SDK.
+
+架构角色：Anthropic 路径的执行引擎，通过 Claude Agent SDK 并行调度多个 specialist subagent。
+核心职责：
+  1. 将每个 Skill 转换为 AgentDefinition，注册为 orchestrator 可调用的子 agent
+  2. 构建包含数据路径的 user prompt，交给 orchestrator 驱动所有 specialist 并行分析
+  3. 流式收集 orchestrator 的最终输出，解析为 AnalysisResult 并统计费用
+与其他模块的关系：由 orchestrator.run_analysis() 在 provider="anthropic" 时调用；
+  反向导入 orchestrator._parse_result 和 AnalysisResult 来处理和封装结果。
+"""
 
 import json
 import logging
@@ -27,7 +36,12 @@ if TYPE_CHECKING:
 
 
 def _build_analysis_prompt(ctx: AnalysisContext, language: str = "en") -> str:
-    """Build the prompt for the orchestrator with context paths."""
+    """构建发给 orchestrator 的 user prompt，将本次分析所有相关数据的文件路径内嵌其中。
+
+    Anthropic 引擎的 specialist 通过文件系统工具（Read/Glob/Grep）直接读取数据，
+    因此只需在 prompt 中提供路径而非数据内容，与 OpenAI 引擎的"内联数据"策略不同。
+    Build the prompt for the orchestrator with context paths.
+    """
     parts = [
         f"Analyze the CI pipelines in: {ctx.local_path}",
         f"\nWorkflow files ({len(ctx.workflow_files)} found):",
@@ -64,14 +78,21 @@ def _build_analysis_prompt(ctx: AnalysisContext, language: str = "en") -> str:
 
 @langfuse_observe(name="anthropic-analysis")
 async def run_analysis_anthropic(ctx: AnalysisContext, config: AgentConfig, skills: "list[Skill]") -> "AnalysisResult":
-    """Run analysis using Claude Agent SDK with dynamically loaded skills."""
+    """使用 Claude Agent SDK 执行并行多专家分析，由 orchestrator subagent 统一调度。
+
+    Run analysis using Claude Agent SDK with dynamically loaded skills.
+
+    SDK 的 "Agent" tool 允许 orchestrator 在同一次对话中并行调用所有 specialist；
+    这里只设置 allowed_tools=["Agent"]，禁止 orchestrator 直接使用文件工具，
+    强制其通过 specialist 来完成所有实际分析工作。
+    """
     from ci_optimizer.agents.orchestrator import AnalysisResult
     from ci_optimizer.agents.skill_registry import SkillRegistry
 
-    # Build agents from skills
+    # 将每个 Skill 转为 AgentDefinition，以技能名为 key 注册进 SDK 的 agents 字典
     agents = {s.name: s.to_agent_definition(config.model) for s in skills}
 
-    # Build orchestrator prompt dynamically
+    # 每次动态生成 orchestrator prompt，使其精确反映本次激活的技能集合
     registry = SkillRegistry()
     orchestrator_prompt = registry.build_orchestrator_prompt(skills)
 

--- a/src/ci_optimizer/agents/failure_triage.py
+++ b/src/ci_optimizer/agents/failure_triage.py
@@ -1,5 +1,13 @@
 """Single-run CI failure diagnosis runner.
 
+架构角色：独立的 standalone skill 执行器，专门处理 /api/ci-runs/diagnose 端点的单次故障诊断请求。
+核心职责：
+  1. 从 SkillRegistry 加载 "failure-triage" skill 的 prompt
+  2. 对单条错误日志片段发起一次性 LLM 调用（无工具调用、无并行、无综合步骤）
+  3. 解析并严格校验返回的 JSON（category、confidence 枚举值），提供优雅降级而非抛出异常
+与其他模块的关系：不经过 orchestrator 调度，直接被 API 路由层调用；
+  通过 provider routing（model 名称前缀判断）支持 Anthropic 和 OpenAI 两套 SDK。
+
 Invokes the ``failure-triage`` skill on a single error excerpt and parses
 the resulting strict JSON. Unlike the multi-specialist orchestrator, this
 is a **one-shot** LLM call — no tool use, no parallelism, no synthesis.
@@ -39,10 +47,17 @@ _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 
 class FailureTriageError(Exception):
-    """Raised when the skill is unavailable or the LLM call fails irrecoverably."""
+    """技能不可用或 LLM 调用无法恢复时抛出，区别于可降级的格式解析错误。
+
+    Raised when the skill is unavailable or the LLM call fails irrecoverably.
+    """
 
 
 def _load_prompt() -> str:
+    """从注册表获取 failure-triage skill 的 prompt，若首次未找到则强制 reload 后重试。
+
+    reload 重试是为了应对注册表在 skill 文件写入之前已经初始化的竞态场景。
+    """
     skill = get_registry().get_skill("failure-triage")
     if skill is None:
         # Try a reload in case the registry was loaded before the skill was created.
@@ -58,10 +73,13 @@ def _build_user_message(*, workflow: str, failing_step: str | None, excerpt: str
 
 
 def _parse_diagnosis(raw: str, failing_step: str | None) -> dict[str, Any]:
-    """Extract the JSON object, validate enums, return a clean dict.
+    """从 LLM 原始响应中提取 JSON，校验枚举字段，返回规范化的诊断结果。
 
+    Extract the JSON object, validate enums, return a clean dict.
     Falls back to category=unknown / confidence=low on malformed output so
     callers always get a usable response.
+
+    root_cause 截断至 300 字符、quick_fix 截断至 500 字符，防止异常长输出污染 API 响应。
     """
     match = _JSON_OBJECT_RE.search(raw.strip())
     if not match:
@@ -115,7 +133,11 @@ async def _call_anthropic(
     model: str,
     config: AgentConfig,
 ) -> tuple[str, float | None]:
-    """Single Anthropic Messages API call. Returns (raw_text, cost_usd)."""
+    """向 Anthropic Messages API 发起单次调用，返回 (原始文本, 估算费用)。
+
+    Single Anthropic Messages API call. Returns (raw_text, cost_usd).
+    使用低 temperature（0.1）以获得稳定、可重复的诊断结果。
+    """
     try:
         from anthropic import AsyncAnthropic
     except ImportError as e:
@@ -133,6 +155,8 @@ async def _call_anthropic(
         parts = [b.text for b in resp.content if getattr(b, "type", None) == "text"]
         text = "".join(parts)
         # Anthropic SDK exposes usage but not cost; caller may compute via Langfuse.
+        # Anthropic SDK exposes usage but not cost; caller may compute via Langfuse.
+        # 此处基于内置价格表做本地估算，Langfuse 可提供更精确的追踪数据
         cost = _estimate_anthropic_cost(model, resp.usage.input_tokens, resp.usage.output_tokens)
         return text, cost
     finally:
@@ -170,6 +194,7 @@ async def _call_openai(
         await client.close()
 
 
+# 粗略费用估算表（美元/百万 token），未知模型返回 None 而非猜测。
 # Rough cost table (USD per 1M tokens). Undercounts on unknown models by returning None.
 _ANTHROPIC_PRICES = {
     # (input, output) per 1M tokens
@@ -208,7 +233,9 @@ async def diagnose(
     model: str,
     config: AgentConfig,
 ) -> dict[str, Any]:
-    """Run the failure-triage skill on a single error excerpt.
+    """对单条 CI 错误日志片段执行故障诊断，是本模块对外暴露的唯一公共接口。
+
+    Run the failure-triage skill on a single error excerpt.
 
     Returns a dict with keys:
         category, confidence, root_cause, quick_fix, failing_step,
@@ -217,6 +244,8 @@ async def diagnose(
     The ``category`` and ``confidence`` fields are always validated against
     their enums; malformed LLM output degrades to ``unknown`` / ``low`` rather
     than raising.
+
+    通过 model 名称前缀（"claude" 开头）选择 provider，避免暴露额外配置项。
     """
     if not excerpt.strip():
         raise FailureTriageError("empty excerpt — nothing to diagnose")

--- a/src/ci_optimizer/agents/openai_engine.py
+++ b/src/ci_optimizer/agents/openai_engine.py
@@ -1,4 +1,13 @@
-"""OpenAI-compatible engine — runs analysis via OpenAI chat completions API."""
+"""OpenAI-compatible engine — runs analysis via OpenAI chat completions API.
+
+架构角色：OpenAI 路径的执行引擎，通过两阶段策略（并行专家调用 → 综合 synthesis）实现多维分析。
+核心职责：
+  1. 将每个 specialist 所需的数据内容直接内联到 prompt 中（因 OpenAI 模型无文件系统访问能力）
+  2. 并行异步调用所有 specialist，每个 specialist 独立分析自己关注的数据维度
+  3. 将所有 specialist 输出拼接后交给综合 call 生成最终 JSON 报告；综合失败时降级为 fallback combine
+与其他模块的关系：由 orchestrator.run_analysis() 在 provider="openai" 时调用；
+  也支持 OpenAI-compatible 第三方端点（通过 base_url 配置）。
+"""
 
 import asyncio
 import json
@@ -19,7 +28,12 @@ if TYPE_CHECKING:
 
 
 def _build_context_for_skill(ctx: AnalysisContext, requires: list[str]) -> str:
-    """Build context text for a single skill based on its requires_data."""
+    """为单个 specialist 构建上下文文本，只内联该 specialist 声明需要的数据。
+
+    按需内联而非全量注入，避免超出模型上下文窗口；
+    大文件（jobs > 30KB, logs > 20KB）会被截断并附加提示。
+    Build context text for a single skill based on its requires_data.
+    """
     parts = []
     if ctx.owner:
         parts.append(f"Repository: {ctx.owner}/{ctx.repo}")
@@ -77,7 +91,12 @@ async def _call_specialist(
     context_text: str,
     language: str,
 ) -> str:
-    """Call a single specialist and return its response via streaming."""
+    """调用单个 specialist 并通过流式模式返回其完整响应。
+
+    Call a single specialist and return its response via streaming.
+    # Use streaming to work around proxies that return content:null in non-stream mode
+    使用流式请求是为了绕过某些代理在非流式模式下返回 content:null 的兼容性问题。
+    """
     lang_instruction = LANGUAGE_INSTRUCTIONS.get(language, LANGUAGE_INSTRUCTIONS["en"])
 
     # Use streaming to work around proxies that return content:null in non-stream mode
@@ -101,7 +120,11 @@ async def _call_specialist(
 
 
 async def run_analysis_openai(ctx: AnalysisContext, config: AgentConfig, skills: "list[Skill]") -> "AnalysisResult":  # noqa: E501
-    """Run analysis using OpenAI-compatible API with parallel specialist calls."""
+    """使用 OpenAI-compatible API 执行两阶段多专家分析。
+
+    Run analysis using OpenAI-compatible API with parallel specialist calls.
+    当 Langfuse tracing 启用时，替换 AsyncOpenAI client 为 langfuse 的 drop-in 版本以自动追踪 LLM 调用。
+    """
     start_time = time.time()
 
     # Use Langfuse drop-in when tracing is enabled
@@ -208,6 +231,7 @@ async def _run_analysis_with_client(
     logger.info(f"Parsed: {len(findings)} findings, stats={stats}")
 
     if not findings:
+        # 综合步骤未能产出 findings（例如模型输出格式错误），降级为直接拼接各 specialist 原始结果
         # If synthesis didn't produce findings, try fallback combine
         logger.warning("No findings from synthesis, trying fallback combine from specialist results")
         fallback = _fallback_combine(specialist_results)
@@ -231,7 +255,11 @@ async def _run_analysis_with_client(
 
 
 def _fallback_combine(specialist_results: dict[str, str]) -> str:
-    """Combine specialist results without orchestrator synthesis."""
+    """在综合 LLM 调用失败时，直接从各 specialist 原始输出中提取 findings 并拼装成合法的结果 JSON。
+
+    Combine specialist results without orchestrator synthesis.
+    此函数是最后的安全网，确保即使综合步骤彻底失败，API 层仍能返回有用的 findings 而非空结果。
+    """
     all_findings = []
     for dim_name, report_text in specialist_results.items():
         try:

--- a/src/ci_optimizer/agents/orchestrator.py
+++ b/src/ci_optimizer/agents/orchestrator.py
@@ -1,4 +1,13 @@
-"""Orchestrator — routes analysis to the configured engine (Anthropic or OpenAI)."""
+"""Orchestrator — routes analysis to the configured engine (Anthropic or OpenAI).
+
+架构角色：agents 层的入口调度器，负责将分析请求路由到正确的引擎（Anthropic 或 OpenAI）。
+核心职责：
+  1. 从 SkillRegistry 获取当前激活的技能列表
+  2. 根据 AgentConfig.provider 分发到 anthropic_engine 或 openai_engine
+  3. 定义通用数据结构 AnalysisResult，以及 JSON 解析工具函数
+与其他模块的关系：被上层 API 路由（FastAPI handler）调用；引擎层（anthropic/openai_engine）
+  反向导入 AnalysisResult 和 _parse_result 以填充并返回统一的结果对象。
+"""
 
 import json
 from dataclasses import dataclass, field
@@ -10,7 +19,11 @@ from ci_optimizer.prefetch import AnalysisContext
 
 @dataclass
 class AnalysisResult:
-    """Structured result from analysis."""
+    """跨引擎统一的分析结果结构。
+
+    由 anthropic_engine 或 openai_engine 填充并返回给上层调用者。
+    findings 是所有 specialist 产出的扁平化 finding 列表，每条已注入 dimension 字段。
+    """
 
     executive_summary: str = ""
     findings: list[dict] = field(default_factory=list)
@@ -21,7 +34,11 @@ class AnalysisResult:
 
 
 def _try_parse_json(raw_text: str) -> dict | None:
-    """Try multiple strategies to extract JSON from raw text."""
+    """尝试多种策略从 LLM 原始输出中提取 JSON 对象。
+
+    LLM 输出格式不稳定（裸 JSON / Markdown 代码块 / 混合文本），
+    此函数按优先级依次尝试三种解析方式，降低因格式差异导致的解析失败率。
+    """
     # Strategy 1: entire text is JSON
     try:
         return json.loads(raw_text.strip())
@@ -54,11 +71,14 @@ def _parse_result(
     raw_text: str,
     dimension_to_skill: dict[str, str] | None = None,
 ) -> tuple[str, list[dict], dict]:
-    """Parse the orchestrator's output into structured data.
+    """将 orchestrator 的原始输出解析为结构化数据三元组 (summary, findings, stats)。
 
     dimension_to_skill: optional mapping from dimension name to skill name,
     used to tag each finding with the skill that produced it. Callers can
     build this from the active skills list.
+
+    解析失败时优雅降级：返回 (raw_text, [], {"total_findings": 0})，
+    不抛出异常，确保 API 层始终得到可用响应。
     """
     dim_map = dimension_to_skill or {}
     try:
@@ -101,13 +121,15 @@ async def run_analysis(
     config: AgentConfig | None = None,
     selected_skills: list[str] | None = None,
 ) -> AnalysisResult:
-    """Run analysis using the configured provider engine.
+    """执行 CI 分析的顶层入口，按配置的 provider 路由到对应引擎。
 
     Routes to:
       - Anthropic engine (Claude Agent SDK) when provider="anthropic"
       - OpenAI engine (OpenAI SDK) when provider="openai"
 
     selected_skills: list of dimension names to run, or None for all.
+
+    此函数是 Langfuse 追踪的根 span，所有子引擎的调用都将挂载在该 trace 下。
     """
     if config is None:
         config = AgentConfig.load()

--- a/src/ci_optimizer/agents/prompts.py
+++ b/src/ci_optimizer/agents/prompts.py
@@ -1,4 +1,12 @@
-"""Shared prompt text and language instructions for all agent engines."""
+"""Shared prompt text and language instructions for all agent engines.
+
+架构角色：所有引擎共享的 prompt 常量仓库，集中维护多语言指令和输出格式规范。
+核心职责：
+  1. LANGUAGE_INSTRUCTIONS：为每种语言提供统一的语言要求注入片段，追加到各 specialist/orchestrator prompt 末尾
+  2. FINDING_JSON_FORMAT：定义 specialist 输出的 JSON schema，自动追加到缺少 "## Output Format" 的 SKILL.md
+与其他模块的关系：被 anthropic_engine、openai_engine、skill_registry 导入；
+  修改此文件会影响所有 specialist 的输出格式，需与 orchestrator 的解析逻辑保持一致。
+"""
 
 LANGUAGE_INSTRUCTIONS = {
     "zh": (

--- a/src/ci_optimizer/agents/skill_importer.py
+++ b/src/ci_optimizer/agents/skill_importer.py
@@ -1,5 +1,13 @@
 """Skill importer — convert external SKILL.md files into ci-agent format.
 
+架构角色：外部技能的适配导入层，负责将来自不同系统的 SKILL.md 格式转换为 ci-agent 兼容格式。
+核心职责：
+  1. 从 Claude Code、OpenCode、本地路径或 GitHub 仓库导入技能定义
+  2. 规范化字段差异（如 allowed-tools → tools、补充 dimension 和 requires_data）
+  3. 写入 ~/.ci-agent/skills/<name>/ 并通过 SkillRegistry 进行校验
+与其他模块的关系：供 CLI 命令（`ci-agent skill import`）调用，导入后的技能由 SkillRegistry 加载；
+  ci-agent 的 SKILL.md schema 是 Claude Code/OpenCode schema 的超集（多了 dimension、requires_data）。
+
 Supports importing from:
   - Claude Code (~/.claude/skills/<name>/SKILL.md)
   - OpenCode (~/.config/opencode/skills/<name>/SKILL.md)
@@ -40,11 +48,16 @@ OPENCODE_SKILLS_DIR = Path.home() / ".config" / "opencode" / "skills"
 
 
 class SkillImportError(Exception):
-    """Raised when a skill cannot be imported."""
+    """技能导入失败时抛出，涵盖格式错误、字段缺失、校验失败等不可恢复情形。
+
+    Raised when a skill cannot be imported.
+    """
 
 
 @dataclass
 class ImportResult:
+    """导入操作的结果，包含目标路径、来源信息和非致命警告列表。"""
+
     name: str
     target_path: Path
     dimension: str
@@ -68,7 +81,10 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
 
 
 def _normalize_name(raw: str) -> str:
-    """Convert a skill name to a filesystem-safe directory name."""
+    """将技能名规范化为文件系统安全的目录名（小写、连字符分隔）。
+
+    Convert a skill name to a filesystem-safe directory name.
+    """
     safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", raw.strip().lower())
     return safe.strip("-") or "unnamed-skill"
 
@@ -90,9 +106,10 @@ def _normalize_frontmatter(
     requires_data: list[str] | None,
     source_kind: str,
 ) -> tuple[dict, list[str]]:
-    """Map foreign frontmatter to ci-agent's schema.
+    """将外部 SKILL.md 的 frontmatter 映射到 ci-agent 的 schema，返回 (规范化 meta, 警告列表)。
 
-    Returns (normalized_meta, warnings).
+    Map foreign frontmatter to ci-agent's schema. Returns (normalized_meta, warnings).
+    dimension 是 ci-agent 必需但外部格式通常没有的字段，必须由调用方通过参数或源文件提供。
     """
     warnings: list[str] = []
     out: dict = {}
@@ -159,10 +176,14 @@ def import_from_path(
     source_kind: str = "path",
     name_override: str | None = None,
 ) -> ImportResult:
-    """Import a skill from a local directory containing SKILL.md.
+    """从本地目录导入技能，是所有导入函数的核心实现，其他入口函数最终都调用此函数。
 
+    Import a skill from a local directory containing SKILL.md.
     The directory must have a SKILL.md at its root. After normalization
     the result is written to ~/.ci-agent/skills/<name>/.
+
+    companion 文件（README、hooks.py 等）会原样复制，不做格式转换。
+    写入后通过 SkillRegistry 做一次完整的解析校验，失败则回滚删除目标目录。
     """
     source_dir = Path(source_dir).expanduser().resolve()
     if not source_dir.is_dir():
@@ -262,12 +283,15 @@ def install_from_github(
     requires_data: list[str] | None = None,
     target_dir: Path | None = None,
 ) -> ImportResult:
-    """Clone a GitHub repo containing a skill and import it.
+    """从 GitHub 仓库 clone 并导入技能，clone 到临时目录后复用 import_from_path 逻辑。
 
+    Clone a GitHub repo containing a skill and import it.
     Accepted formats:
       - https://github.com/owner/repo
       - git@github.com:owner/repo.git
       - gh:owner/repo  (shorthand)
+
+    使用 --depth=1 浅克隆降低带宽消耗；导入完成后临时目录由 TemporaryDirectory 自动清理。
     """
     if url.startswith("gh:"):
         url = f"https://github.com/{url[3:]}"

--- a/src/ci_optimizer/agents/skill_registry.py
+++ b/src/ci_optimizer/agents/skill_registry.py
@@ -1,4 +1,13 @@
-"""Skill registry — discovers, parses, validates, and manages SKILL.md definitions."""
+"""Skill registry — discovers, parses, validates, and manages SKILL.md definitions.
+
+架构角色：技能（子 agent）的配置管理层，将磁盘上的 SKILL.md 文件转化为运行时可用的 Skill 对象。
+核心职责：
+  1. 扫描 builtin（项目内 skills/）和 user（~/.ci-agent/skills/）两个目录，同名技能以用户定义优先
+  2. 解析 SKILL.md 的 YAML frontmatter + 正文，并对字段进行校验
+  3. 动态生成 orchestrator 的 system prompt，使其知道要调度哪些 specialist
+与其他模块的关系：orchestrator.py、anthropic_engine.py、openai_engine.py 均通过 get_registry()
+  获取全局单例来查询激活的技能列表；failure_triage.py 通过 get_skill("failure-triage") 获取独立技能。
+"""
 
 import logging
 from dataclasses import dataclass, field
@@ -19,7 +28,12 @@ _USER_DIR = Path.home() / ".ci-agent" / "skills"
 
 @dataclass
 class Skill:
-    """A single analysis skill parsed from SKILL.md."""
+    """从 SKILL.md 解析得到的单个分析技能，代表一个 specialist subagent 的完整定义。
+
+    dimension 对应分析维度（如 "security"、"performance"），是 orchestrator 组织结果的分类键。
+    requires_data 决定 prefetch 阶段需要预先加载哪些数据（工作流文件、运行日志等）。
+    standalone=True 的技能（如 failure-triage）不参与多专家编排流程，由专属 API 直接调用。
+    """
 
     name: str
     description: str
@@ -36,7 +50,10 @@ class Skill:
     standalone: bool = False
 
     def to_agent_definition(self, model: str | None = None):
-        """Convert to Claude Agent SDK AgentDefinition."""
+        """将 Skill 转换为 Claude Agent SDK 所需的 AgentDefinition 格式。
+
+        仅在 Anthropic 引擎路径下使用；OpenAI 引擎直接使用 skill.prompt 字符串。
+        """
         from claude_agent_sdk import AgentDefinition
 
         kwargs = dict(
@@ -50,7 +67,11 @@ class Skill:
 
 
 class SkillRegistry:
-    """Discovers and manages skills from builtin and user directories."""
+    """从 builtin 和 user 两个目录发现并管理所有技能定义。
+
+    采用"用户目录覆盖内置目录"的策略，允许用户在不修改项目代码的情况下覆盖或扩展技能。
+    通常通过模块级单例 get_registry() 访问，避免每次请求重复扫描文件系统。
+    """
 
     def __init__(
         self,
@@ -62,7 +83,10 @@ class SkillRegistry:
         self._skills: dict[str, Skill] = {}
 
     def load(self) -> "SkillRegistry":
-        """Scan builtin + user directories. User skills override builtin by name."""
+        """扫描 builtin 和 user 目录并填充技能字典，支持链式调用。
+
+        User skills override builtin by name.
+        """
         self._skills.clear()
         self._load_dir(self._builtin_dir, source="builtin")
         self._load_dir(self._user_dir, source="user")
@@ -91,7 +115,12 @@ class SkillRegistry:
 
     @staticmethod
     def _parse_skill_md(path: Path, source: str) -> Skill:
-        """Parse SKILL.md: YAML frontmatter + body."""
+        """解析单个 SKILL.md 文件：提取 YAML frontmatter 和正文 prompt。
+
+        若 prompt 中不含 "## Output Format"，则自动追加标准 JSON 输出格式说明，
+        确保所有 specialist 的输出格式一致，便于 orchestrator 聚合。
+        Parse SKILL.md: YAML frontmatter + body.
+        """
         text = path.read_text(encoding="utf-8")
         parts = text.split("---", 2)
         if len(parts) < 3:
@@ -135,11 +164,14 @@ class SkillRegistry:
         return errors
 
     def get_active_skills(self, selected: list[str] | None = None) -> list[Skill]:
-        """Return enabled skills for the multi-specialist orchestrator.
+        """返回用于多专家编排流程的激活技能列表，按 priority 降序排列。
 
         Standalone skills (e.g., failure-triage) are excluded because they
         have a different input contract and are invoked directly by their
         own API endpoint. Use ``get_skill(name)`` to access them.
+
+        selected 为 None 时返回全部非 standalone 技能；否则按 dimension 名过滤，
+        允许用户在 API 请求中指定只运行哪些分析维度。
         """
         skills = [s for s in self._skills.values() if s.enabled and not s.standalone]
         if selected:
@@ -165,7 +197,12 @@ class SkillRegistry:
         return self
 
     def build_orchestrator_prompt(self, skills: list[Skill]) -> str:
-        """Dynamically generate orchestrator prompt from active skills."""
+        """根据当前激活的技能列表动态生成 orchestrator 的 system prompt。
+
+        将 dimension 名称、各 specialist 描述、以及期望的 JSON 输出 schema 内嵌进 prompt，
+        使 orchestrator 知道要调用哪些 specialist 以及最终输出的结构。
+        Dynamically generate orchestrator prompt from active skills.
+        """
         dim_list = "\n".join(f"{i + 1}. **{s.dimension}**: {s.description}" for i, s in enumerate(skills))
         agent_list = "\n".join(f"   - **{s.name}**: {s.description}" for s in skills)
         dim_schema = "\n".join(f'    "{s.dimension}": {{ "findings": [...] }},' for s in skills)
@@ -211,7 +248,9 @@ _global_registry: SkillRegistry | None = None
 
 
 def get_registry() -> SkillRegistry:
-    """Return a lazily-initialized, process-wide SkillRegistry singleton.
+    """返回进程级 SkillRegistry 单例（懒初始化）。
+
+    Return a lazily-initialized, process-wide SkillRegistry singleton.
 
     Use this from long-lived code paths (API routes, engines) so we don't
     re-scan the filesystem on every request. Call ``get_registry().reload()``
@@ -219,6 +258,8 @@ def get_registry() -> SkillRegistry:
 
     Tests and CLI one-shots that want isolation can still construct a
     ``SkillRegistry(...)`` directly.
+
+    设计权衡：单例模式避免每次 API 请求重扫文件系统，但热更新时需要手动调用 reload()。
     """
     global _global_registry
     if _global_registry is None:

--- a/src/ci_optimizer/agents/tracing.py
+++ b/src/ci_optimizer/agents/tracing.py
@@ -1,5 +1,13 @@
 """Langfuse tracing integration.
 
+架构角色：可观测性基础设施层，为整个 agents 层提供统一的 LLM 调用追踪能力。
+核心职责：
+  1. 懒初始化 Langfuse 客户端（首次调用时检查环境变量，避免导入时副作用）
+  2. 提供 langfuse_observe 装饰器，同时支持 async 和 sync 函数，未配置时退化为 no-op
+  3. 提供 flush() 保证异步任务结束时追踪数据不丢失
+与其他模块的关系：orchestrator、anthropic_engine、openai_engine、failure_triage 均导入此模块；
+  OpenAI engine 在 tracing 启用时会替换 client 为 langfuse 的 drop-in 版本以自动追踪 API 调用。
+
 Provides a thin wrapper around Langfuse SDK. When LANGFUSE_SECRET_KEY
 is not configured, all tracing is silently disabled — zero impact on
 existing behavior.
@@ -24,7 +32,11 @@ _langfuse_enabled: bool | None = None  # None = not yet checked
 
 
 def _ensure_init():
-    """Lazy-initialize Langfuse on first use (after load_dotenv has run)."""
+    """延迟初始化 Langfuse，确保在 load_dotenv 加载环境变量之后才读取配置。
+
+    Lazy-initialize Langfuse on first use (after load_dotenv has run).
+    使用 _langfuse_enabled=None 作为"尚未检查"的哨兵值，区别于已检查但禁用的 False。
+    """
     global _langfuse_instance, _langfuse_enabled
 
     if _langfuse_enabled is not None:
@@ -75,9 +87,13 @@ def flush():
 
 
 def langfuse_observe(name: str | None = None, **kwargs: Any) -> Callable:
-    """Decorator that wraps langfuse @observe() when enabled, otherwise a no-op.
+    """将函数包装为 Langfuse trace span 的装饰器；未配置 Langfuse 时退化为透明包装。
 
+    Decorator that wraps langfuse @observe() when enabled, otherwise a no-op.
     Uses lazy check so the decorator resolves at call time, not import time.
+
+    分别为 async 和 sync 函数提供对应的 wrapper，通过 inspect.iscoroutinefunction 在装饰时区分。
+    Langfuse observe 调用失败时静默回退到原始函数，避免追踪逻辑影响业务可用性。
     """
 
     def decorator(func: Callable) -> Callable:

--- a/src/ci_optimizer/api/__init__.py
+++ b/src/ci_optimizer/api/__init__.py
@@ -1,0 +1,10 @@
+# ci_optimizer.api 包
+# 本包是 CI Agent 的 HTTP API 层，包含以下模块：
+#   app.py      — FastAPI 应用实例，挂载所有路由，配置 CORS 和日志
+#   routes.py   — 分析、报告、skill 管理、配置等 REST 端点（/api 前缀）
+#   chat.py     — 流式聊天端点（SSE），核心是多轮 tool-use agentic loop
+#   tools.py    — chat agent 可调用的工具定义与执行器（含路径沙箱和命令白名单）
+#   auth.py     — API Key Bearer token 鉴权依赖注入
+#   diagnose.py — CI 失败诊断端点，三级缓存策略 + failure_triage skill 调用
+#   schemas.py  — 所有请求/响应的 Pydantic 数据模型
+#   webhooks.py — GitHub webhook 处理（workflow_run 事件 → 分析 + 自动诊断）

--- a/src/ci_optimizer/api/app.py
+++ b/src/ci_optimizer/api/app.py
@@ -1,4 +1,10 @@
 """FastAPI application setup."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件是整个 API 层的入口，负责创建 FastAPI app 实例并完成三项初始化工作：
+#   1. 配置 ci_optimizer 命名空间的日志（确保后台任务输出在 uvicorn 控制台可见）
+#   2. 通过 lifespan 钩子在启动时初始化数据库并预热 skill 注册表
+#   3. 注册所有子路由（REST 分析、诊断、流式聊天、webhook）并配置 CORS
+# 上游：uvicorn 入口；下游：routes / chat / diagnose / webhooks 四个路由模块。
 
 import logging
 import os
@@ -36,6 +42,7 @@ _ci_logger.propagate = False
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """应用生命周期钩子：启动时完成数据库初始化和 skill 注册表预热，避免首次请求承担冷启动延迟。"""
     await init_db()
     # Preload the skill registry singleton so the first request doesn't pay the scan cost.
     from ci_optimizer.agents.skill_registry import get_registry
@@ -74,5 +81,7 @@ app.include_router(chat_router)
 
 @app.get("/health", tags=["health"])
 async def health():
-    """Liveness / readiness probe endpoint."""
+    """Liveness / readiness probe endpoint.
+    用于 k8s 健康检查或负载均衡器探活，无需鉴权。
+    """
     return {"status": "ok"}

--- a/src/ci_optimizer/api/auth.py
+++ b/src/ci_optimizer/api/auth.py
@@ -1,10 +1,16 @@
 """API key authentication dependency."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件提供 FastAPI 依赖注入函数 verify_api_key，被所有需要鉴权的路由通过
+# dependencies=[Depends(verify_api_key)] 引用。
+# 设计决策：未设置 CI_AGENT_API_KEY 时跳过鉴权，便于本地开发零配置启动；
+# 生产部署时通过环境变量注入密钥即可启用。
 
 import os
 
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+# auto_error=False：让我们自己控制 401 响应，而不是 FastAPI 默认的 403
 _security = HTTPBearer(auto_error=False)
 
 
@@ -15,6 +21,7 @@ async def verify_api_key(
 
     When CI_AGENT_API_KEY is not set, authentication is skipped entirely
     (backward-compatible for local development).
+    校验逻辑：读取环境变量 → 未配置则放行 → 配置了则要求 Bearer token 完全匹配。
     """
     api_key = os.getenv("CI_AGENT_API_KEY")
     if not api_key:

--- a/src/ci_optimizer/api/chat.py
+++ b/src/ci_optimizer/api/chat.py
@@ -1,4 +1,12 @@
 """Streaming chat endpoint for the CI Agent TUI and web frontend."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件实现 CI Agent 的流式对话层，是整个 chat 功能的核心模块。
+# 关键设计：
+#   - 使用 Server-Sent Events（SSE）将 text / tool_use / tool_result / done 逐步推给前端
+#   - _run_agentic_loop 是多轮 tool-use 的状态机：每轮调用 LLM → 执行只读工具 → 继续，
+#     遇到写操作则生成 write_proposal 事件并暂停，等待 POST /chat/apply 确认后再执行
+#   - 同时支持 Anthropic（原生 tool_use）和 OpenAI（function calling）两种提供商
+# 与 tools.py（工具定义与执行）、auth.py（鉴权）、config.py（模型配置）协作。
 
 from __future__ import annotations
 
@@ -73,12 +81,17 @@ class ChatRequest(BaseModel):
 
 
 def _sse_event(event: str, data: dict) -> str:
-    """Format a single SSE event."""
+    """Format a single SSE event.
+    拼接标准 SSE 格式字符串；ensure_ascii=False 保证中文内容正常传输。
+    """
     return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
 def _serialize_content(content) -> list[dict]:
-    """Serialize Anthropic content blocks to JSON-safe dicts for round-tripping."""
+    """Serialize Anthropic content blocks to JSON-safe dicts for round-tripping.
+    write_proposal 事件需要把整轮 assistant content 序列化后发给前端，
+    以便 /chat/apply 完成后前端可以还原上下文继续对话。
+    """
     result = []
     for block in content:
         if block.type == "text":
@@ -100,7 +113,13 @@ async def _run_agentic_loop(
     repo_root: Path | None,
     max_turns: int = 10,
 ):
-    """多轮 tool-use 循环。Yield SSE 事件字符串。"""
+    """多轮 tool-use 循环。Yield SSE 事件字符串。
+
+    每一轮：调用 LLM → 流出 text/tool_use 事件 → 若有只读工具则执行并继续；
+    若遇到写操作，生成 write_proposal 事件后立即 return（暂停生成器），
+    由前端用户确认后再调用 /chat/apply 触发实际写入。
+    repo_root 为 None 时禁用所有工具（纯问答模式）。
+    """
     tools = ANTHROPIC_TOOLS if repo_root else []
     total_input = 0
     total_output = 0
@@ -238,14 +257,14 @@ async def _run_agentic_loop(
 
 @chat_router.post("/chat")
 async def chat(request: ChatRequest):
-    """Streaming chat endpoint. Returns SSE (Server-Sent Events).
+    """流式对话入口，返回 SSE 流。根据 provider 配置分发到 Anthropic 或 OpenAI 后端。
 
-    Events:
-      - event: text         data: {"content": "..."}
-      - event: tool_use     data: {"id": "...", "name": "...", "input": {...}}
-      - event: tool_result  data: {"id": "...", "name": "...", "result_preview": "..."}
-      - event: done         data: {"usage": {...}, "model": "...", "turns": N}
-      - event: error        data: {"message": "..."}
+    SSE 事件类型：
+      - event: text         data: {"content": "..."}          — LLM 文本输出片段
+      - event: tool_use     data: {"id": "...", "name": "...", "input": {...}}  — 工具调用
+      - event: tool_result  data: {"id": "...", "name": "...", "result_preview": "..."}  — 工具结果预览
+      - event: done         data: {"usage": {...}, "model": "...", "turns": N}  — 完成（含 token 消耗）
+      - event: error        data: {"message": "..."}           — 异常
     """
 
     async def _generate():
@@ -302,7 +321,10 @@ class ApplyRequest(BaseModel):
 
 @chat_router.post("/chat/apply")
 async def apply_writes(request: ApplyRequest):
-    """执行用户确认的写入操作。返回每个操作的结果。"""
+    """执行用户确认的写入操作，返回每个操作的执行结果。
+    此端点是 write_proposal 事件的后续步骤：前端展示 diff 让用户确认后，
+    将 proposals 列表 POST 到这里，服务端执行实际的文件写入或 git commit。
+    """
     repo_root = Path(request.repo_root)
     if not repo_root.exists() or not repo_root.is_dir():
         return {"error": "repo_root not found"}
@@ -331,7 +353,9 @@ async def _query_anthropic(
     base_url: str | None,
     repo_root: Path | None = None,
 ):
-    """通过 Anthropic SDK 查询，支持 tool use 和代理。"""
+    """通过 Anthropic SDK 查询，支持 tool use 和代理。
+    base_url 会做后缀清理（去掉 /v1/messages 或 /v1），因为 SDK 自动拼接路径。
+    """
     import anthropic
 
     # 去掉 /v1/messages 或 /v1 — SDK 自动拼接
@@ -363,7 +387,9 @@ async def _query_openai(
     config: AgentConfig,
     repo_root: "Path | None" = None,
 ):
-    """通过 OpenAI SDK 查询，支持多轮 tool use（OpenAI function calling 格式）。"""
+    """通过 OpenAI SDK 查询，支持多轮 tool use（OpenAI function calling 格式）。
+    注意：OpenAI 路径目前不实现 write_proposal 拦截，写操作会直接执行。
+    """
     import json
 
     from openai import AsyncOpenAI

--- a/src/ci_optimizer/api/diagnose.py
+++ b/src/ci_optimizer/api/diagnose.py
@@ -6,6 +6,16 @@ v1 replaces v0's in-memory cache with DB persistence:
 - Daily budget tracker for webhook auto-diagnosis (manual calls always proceed)
 
 v0 in-memory cache is removed. Frontend integration lands in v2 (#32).
+
+架构角色：
+  本文件提供 CI 失败诊断的 REST 端点，核心是 run_diagnosis() 共享函数——
+  手动 API 调用和 webhook 自动诊断两条路径都复用它。
+  三级缓存策略（精确缓存 → 签名缓存 → 新鲜 LLM 调用）在此函数中实现，
+  目的是控制 LLM 调用成本，对相同错误模式复用已有诊断结果。
+  diagnose_router 挂载在 /api 下，提供：
+    POST /ci-runs/diagnose          — 手动诊断单次 run
+    GET  /diagnoses/by-signature/:sig — 查询同签名失败的历史聚合
+    GET  /repos/:owner/:repo/failed-runs — 列出仓库最近失败 run（直查 GitHub）
 """
 
 from __future__ import annotations
@@ -47,7 +57,9 @@ _REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
 
 
 def _pick_failed_job(jobs: list[dict]) -> dict | None:
-    """Return the first failed job from a list. v0/v1 handles one job per run."""
+    """Return the first failed job from a list. v0/v1 handles one job per run.
+    只取第一个失败 job，以保持诊断结果的单一性，避免混合多个 job 的错误信息。
+    """
     for job in jobs:
         if job.get("conclusion") == "failure":
             return job
@@ -98,12 +110,14 @@ async def run_diagnosis(
     source: Literal["manual", "webhook_auto"],
     config: AgentConfig | None = None,
 ) -> DiagnoseResponse:
-    """Core diagnosis flow — shared by manual API + webhook auto path.
+    """核心诊断流程——被手动 API 和 webhook 自动路径共同复用。
 
-    Cache order:
-        1. Exact cache: same (repo, run, attempt, tier)
-        2. Signature cache: same normalized error within TTL window
-        3. Fresh diagnosis via LLM
+    三级缓存策略：
+        1. 精确缓存：完全相同的 (repo, run, attempt, tier) 直接命中
+        2. 签名缓存：相同归一化错误在 TTL 窗口内复用旧诊断，并为本次 run 存一条新记录（下次精确命中）
+        3. 新鲜 LLM 调用：调用 failure_triage skill，结果持久化到 DB
+    日志提取（extract_error_excerpt）和签名计算（compute_signature）在拿到 log 后立即完成，
+    以便在进入缓存查找前就有确定的签名。
     """
     config = config or AgentConfig.load()
     db_repo = await get_or_create_repo(db, owner, repo_name)
@@ -129,6 +143,8 @@ async def run_diagnosis(
 
         # Fetch the log of the specific failing job, not the whole-run ZIP,
         # so we don't mix output from unrelated passing jobs.
+        # 优先拉取单个失败 job 的日志，避免整个 run ZIP 包中混入其他 job 的噪音；
+        # 若 job 日志不可用（如已过期），退而使用整个 run 的日志。
         log_text = await gh.get_job_log(owner, repo_name, failing_job["id"], max_lines=2000)
         if not log_text:
             # Fall back to whole-run log if per-job fetch fails (e.g., log expired)
@@ -316,6 +332,8 @@ async def list_failed_runs(
 
     Queries GitHub directly (no DB persistence) so the picker works even
     on repos that have never been analyzed. Returns most recent first.
+    直接查 GitHub API，不走 DB 缓存，因此未被分析过的仓库也能使用此端点（诊断选择器）。
+    GitHub 的 status 过滤不支持 "failure"，需拉取 completed 后客户端过滤。
     """
     if not _REPO_RE.match(f"{owner}/{repo_name}"):
         raise HTTPException(status_code=400, detail="invalid owner/repo")

--- a/src/ci_optimizer/api/routes.py
+++ b/src/ci_optimizer/api/routes.py
@@ -1,4 +1,13 @@
 """FastAPI route handlers."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件是 CI 分析功能的主路由层，统一挂载在 /api 前缀下并要求 API Key 鉴权。
+# 核心职责：
+#   - POST /analyze：接收仓库地址，异步在后台跑分析任务，立即返回 report_id
+#   - GET /reports / /reports/{id}：查询分析报告和明细
+#   - GET/PUT /config：读写运行时 Agent 配置（支持热更新）
+#   - GET/POST/DELETE /skills：管理内置与用户自定义分析 skill
+#   - GET /repositories / /dashboard / /dashboard/trends：统计与趋势视图
+# 与 orchestrator（跑分析）、skill_registry（管理 skill）、db/crud（持久化）深度耦合。
 
 import json
 import os
@@ -46,11 +55,13 @@ router = APIRouter(prefix="/api", dependencies=[Depends(verify_api_key)])
 
 
 async def get_db():
+    """FastAPI 依赖注入：提供异步数据库 session，请求结束后自动关闭。"""
     async with async_session() as session:
         yield session
 
 
 def _to_analysis_filters(schema) -> AnalysisFilters | None:
+    """将 FilterSchema（API 请求体）转换为内部 AnalysisFilters，处理 since/until 对的组合逻辑。"""
     if schema is None:
         return None
     time_range = None
@@ -84,7 +95,9 @@ async def _run_analysis_task(
     config: AgentConfig | None = None,
     selected_skills: list[str] | None = None,
 ):
-    """Background task to run the analysis."""
+    """后台分析任务：在独立协程中完整执行"预取→分析→格式化→入库"流水线。
+    成功时将报告写入 DB，失败时记录错误状态。finally 块负责清理临时文件和克隆目录。
+    """
     import logging
     import shutil
 
@@ -149,7 +162,10 @@ async def analyze(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
-    """Trigger a new CI pipeline analysis."""
+    """触发一次新的 CI 流水线分析。
+    先做缓存查找（同仓库+同过滤条件的近期报告），命中则直接返回；
+    未命中则创建 running 状态的报告记录，将实际分析推入后台任务，立即返回 report_id。
+    """
     # Extract owner/repo without cloning (clone deferred to background task)
     from ci_optimizer.resolver import GITHUB_SHORTHAND_PATTERN, is_github_shorthand, is_github_url, parse_github_url
 
@@ -161,6 +177,7 @@ async def analyze(
         owner, repo_name = match.group(1), match.group(2)
     else:
         # Local path — validate exists and is safe
+        # 本地路径：校验目录存在且含 .github/workflows/，防止路径遍历攻击
         from pathlib import Path
 
         p = Path(repo_input).resolve()
@@ -331,7 +348,9 @@ _FIELD_TO_ENV = {
 
 @router.put("/config")
 async def update_config(updates: AgentConfigSchema):
-    """Update agent configuration. Writes to config.json AND sets env vars in-process."""
+    """更新 Agent 配置：同时写入 config.json 并更新进程内环境变量，使变更立即生效，
+    避免下次 AgentConfig.load() 从 env 读取到旧值而覆盖刚写入的配置。
+    """
     config = AgentConfig.load()
     for field in ("provider", "model", "fallback_model", "anthropic_api_key", "openai_api_key", "github_token", "base_url", "language"):
         val = getattr(updates, field, None)
@@ -389,10 +408,8 @@ async def reload_skills():
 
 @router.post("/skills/import", response_model=SkillImportResponse)
 async def import_skill(req: SkillImportRequest):
-    """Import a skill from Claude Code, OpenCode, a local path, or a GitHub repo.
-
-    After a successful import the in-memory skill registry is reloaded so the
-    new skill is immediately available for subsequent analyses.
+    """从多种来源导入自定义 skill（Claude Code / OpenCode / 本地路径 / GitHub 仓库）。
+    导入成功后立即重载内存中的 skill 注册表单例，让新 skill 对后续分析请求即时可用。
     """
     from pathlib import Path as _P
 

--- a/src/ci_optimizer/api/schemas.py
+++ b/src/ci_optimizer/api/schemas.py
@@ -1,4 +1,11 @@
 """Pydantic request/response schemas for the API."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件是 API 层的数据合约，所有请求体和响应体的 Pydantic 模型都在此定义。
+# 结构分为三组：
+#   - 分析相关（FilterSchema / AgentConfigSchema / AnalyzeRequest / Report* / Dashboard*）
+#   - Skill 管理（SkillSchema / SkillImportRequest / SkillImportResponse）
+#   - 失败诊断（DiagnoseRequest / DiagnoseResponse / SignatureClusterResponse / FailedRunSummary）
+# schemas 只做数据验证，不含业务逻辑；routes.py / diagnose.py 负责将其转换为内部对象。
 
 from datetime import datetime
 from typing import Literal
@@ -7,6 +14,8 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class FilterSchema(BaseModel):
+    """分析过滤条件：时间范围、workflow 名、运行状态、分支，均为可选。"""
+
     since: datetime | None = None
     until: datetime | None = None
     workflows: list[str] | None = None
@@ -15,6 +24,10 @@ class FilterSchema(BaseModel):
 
 
 class AgentConfigSchema(BaseModel):
+    """Agent 配置的可选覆盖项，用于 POST /analyze 的 per-request 覆盖，以及 PUT /config 的全局更新。
+    所有字段均可选，None 表示"不覆盖，保留现有配置"。
+    """
+
     provider: str | None = None  # "anthropic" or "openai"
     model: str | None = None
     fallback_model: str | None = None
@@ -34,6 +47,8 @@ class AnalyzeRequest(BaseModel):
 
 
 class FindingSchema(BaseModel):
+    """单条分析发现的完整字段，用于 GET /reports/{id} 的响应体。"""
+
     id: int
     dimension: str
     skill_name: str | None = None  # which skill produced this finding
@@ -55,6 +70,7 @@ class FindingSchema(BaseModel):
         The LLM sometimes omits the line number or writes '' or 'null' in the
         JSON payload; older DB rows have these values. Coerce to None so the
         API does not fail with HTTP 500 when serving old reports.
+        LLM 偶尔在 JSON 中写出空字符串或字面量 'null'，这里做兼容处理，避免旧报告导致 500。
         """
         if v is None:
             return None
@@ -205,6 +221,8 @@ DiagnoseTier = Literal["default", "deep"]
 
 
 class DiagnoseRequest(BaseModel):
+    """POST /ci-runs/diagnose 的请求体。tier 控制使用轻量还是深度分析模型。"""
+
     repo: str  # "owner/name"
     run_id: int  # GitHub workflow_run.id
     run_attempt: int = 1
@@ -212,6 +230,8 @@ class DiagnoseRequest(BaseModel):
 
 
 class DiagnoseResponse(BaseModel):
+    """诊断结果响应体。cached=True 表示命中了精确缓存或签名缓存（未产生新 LLM 费用）。"""
+
     category: DiagnoseCategory
     confidence: DiagnoseConfidence
     root_cause: str

--- a/src/ci_optimizer/api/tools.py
+++ b/src/ci_optimizer/api/tools.py
@@ -1,6 +1,14 @@
 """CI 专用工具——用于 chat agent。
 
 每个工具在确认的仓库根目录内执行。路径经过验证，防止越界访问。
+
+架构说明：
+  本文件是 chat agent 的"工具箱"，为 LLM 提供可调用的操作集合。
+  TOOL_DEFINITIONS / ANTHROPIC_TOOLS 是工具的 schema 声明（供 LLM 理解参数），
+  execute_tool 是运行时分发器，preview_write 负责写操作的只读预览（生成 diff 但不落盘），
+  validate_path 和 _is_command_safe 是两道安全闸门：防路径遍历 + 防危险命令。
+  写操作（write_file / edit_file / git_commit）被单独列在 WRITE_TOOL_NAMES，
+  chat.py 的 _run_agentic_loop 会拦截这些工具并通过 write_proposal 事件让用户确认。
 """
 
 from __future__ import annotations
@@ -357,6 +365,7 @@ def _exec_read_file(inputs: dict, repo_root: Path) -> str:
         return f"Error: not a file: {inputs['path']}"
     content = path.read_text(errors="replace")
     max_chars = 50_000
+    # 截断超长文件，避免单次工具调用撑满 context window
     if len(content) > max_chars:
         content = content[:max_chars] + f"\n\n... (已截断，共 {len(content)} 字符)"
     return content
@@ -456,6 +465,7 @@ def _exec_edit_file(inputs: dict, repo_root: Path) -> str:
     if old_string not in old_content:
         return f"Error: old_string not found in {inputs['path']}"
     count = old_content.count(old_string)
+    # 仅替换第一个匹配项（与 preview_edit_file 行为一致），避免意外替换重复片段
     new_content = old_content.replace(old_string, new_string, 1)
     path.write_text(new_content)
     return f"Edited {inputs['path']} (replaced 1 of {count} occurrences)"

--- a/src/ci_optimizer/api/webhooks.py
+++ b/src/ci_optimizer/api/webhooks.py
@@ -1,4 +1,12 @@
 """GitHub webhook handler for automated CI analysis."""
+# ── 架构角色 ──────────────────────────────────────────────────────────────────
+# 本文件处理来自 GitHub 的 webhook 事件，是 CI Agent 的被动触发入口。
+# 主要职责：
+#   - 验证 X-Hub-Signature-256 HMAC 签名（WEBHOOK_SECRET 配置后强制校验）
+#   - 处理 workflow_run completed 事件：创建 DB 记录并在后台启动全量分析
+#   - 对失败的 workflow_run，按"开关 + 采样率 + 每日预算"三道门控决定是否触发自动诊断
+#   - 支持简单 {"repo": "owner/name"} 格式的手动 curl 触发
+# 所有耗时操作（分析、诊断）均推入 BackgroundTasks，接口本身立即返回 202。
 
 import hashlib
 import hmac
@@ -50,6 +58,8 @@ async def _run_auto_diagnosis_task(
     Runs in its own session so we don't tie up the webhook request's session
     past the 202 response. Swallows errors so a failing diagnosis never
     poisons the surrounding analysis pipeline.
+    使用独立的 async_session，防止 webhook 请求 session 在 202 返回后被复用；
+    吞掉所有异常（仅 warning 日志），确保自动诊断失败不影响主分析流水线。
     """
     # Late import to break a circular dependency with diagnose.py.
     from ci_optimizer.api.diagnose import run_diagnosis
@@ -82,6 +92,8 @@ async def _should_auto_diagnose(db: AsyncSession, config: AgentConfig) -> tuple[
     """Decide whether to enqueue an auto-diagnosis for a failed webhook run.
 
     Returns (should_run, reason). Reason is useful for logging/debugging.
+    三道门控（按顺序）：全局开关 → 随机采样率 → 今日累计费用预算。
+    reason 字符串用于响应体和日志，方便调试配置是否生效。
     """
     if not config.diagnose_auto_on_webhook:
         return False, "disabled"
@@ -97,6 +109,7 @@ def _verify_signature(payload: bytes, signature_header: str | None, secret: str)
     """Validate X-Hub-Signature-256 HMAC.
 
     Raises HTTPException 401 if the signature is missing or invalid.
+    使用 hmac.compare_digest 进行常数时间比较，防止时序攻击。
     """
     if not signature_header:
         raise HTTPException(status_code=401, detail="Missing X-Hub-Signature-256 header")
@@ -144,6 +157,8 @@ async def github_webhook(
 
     # Track per-event auto-diagnosis intent so we can attach the task AFTER
     # the db.commit() below (BackgroundTasks only run after response send).
+    # 先收集自动诊断的目标信息，等 db.commit() 完成后再添加 background task，
+    # 保证 session 已关闭、DB 数据已持久化时后台任务才开始执行。
     auto_diag_target: dict | None = None
 
     # ── GitHub workflow_run event ──

--- a/src/ci_optimizer/cli.py
+++ b/src/ci_optimizer/cli.py
@@ -1,4 +1,10 @@
 """CLI entry point for ci-agent."""
+# 架构角色：用户交互的最外层入口，所有子命令（analyze/serve/config/skills/chat）
+#           均在此文件中注册和分发，是系统各功能模块的"粘合层"。
+# 核心职责：解析命令行参数、合并配置、将执行流路由到对应的运行函数
+#           （run_analyze / run_serve / run_config / run_skills / run_chat）。
+# 关联模块：依赖 config.py 构建 AgentConfig，依赖 resolver/prefetch/filters
+#           完成数据准备，最终将 ctx 交给 agents/orchestrator 执行分析。
 
 import argparse
 import asyncio
@@ -135,7 +141,11 @@ def parse_args():
 
 
 def _build_config(args) -> "AgentConfig":
-    """Build AgentConfig from saved config + CLI overrides."""
+    """Build AgentConfig from saved config + CLI overrides.
+
+    先从文件/环境变量加载基础配置，再用 CLI 标志做最终覆盖，
+    确保命令行参数拥有最高优先级（高于环境变量）。
+    """
     from ci_optimizer.config import AgentConfig
 
     config = AgentConfig.load()
@@ -156,6 +166,7 @@ def _build_config(args) -> "AgentConfig":
 
 
 async def run_analyze(args):
+    """执行单次 CI 分析的完整流程：配置构建 → 仓库解析 → 数据预取 → Agent 分析 → 报告输出。"""
     from ci_optimizer.agents.orchestrator import run_analysis
     from ci_optimizer.filters import AnalysisFilters
     from ci_optimizer.prefetch import prepare_context
@@ -297,7 +308,11 @@ def run_config(args):
 
 
 def _validate_skill_path(path: Path) -> int:
-    """Validate one or more SKILL.md files. Returns 0 on success, 1 on failure."""
+    """Validate one or more SKILL.md files. Returns 0 on success, 1 on failure.
+
+    支持三种输入形式：单个 SKILL.md 文件、包含 SKILL.md 的技能目录、
+    或内含多个子技能目录的父目录。对 requires_data 字段错误还会给出"你是否想写 X？"的提示。
+    """
     from ci_optimizer.agents.skill_registry import (
         VALID_REQUIRES_DATA,
         SkillRegistry,
@@ -327,6 +342,7 @@ def _validate_skill_path(path: Path) -> int:
         return 1
 
     # "did you mean" for unknown requires_data values
+    # 用字符共现度做轻量相似度匹配，不引入 difflib 依赖
     def _suggest(bad: str) -> str | None:
         best: tuple[int, str] | None = None
         for candidate in VALID_REQUIRES_DATA:
@@ -545,6 +561,11 @@ def run_skills(args):
 
 
 def run_chat(args):
+    """启动 TUI 交互模式。
+
+    通过设置环境变量来传递 model override，而非直接修改 config 对象，
+    这样 run_tui() 内部再次调用 AgentConfig.load() 时能自动感知。
+    """
     from pathlib import Path
 
     from ci_optimizer.tui.app import run_tui

--- a/src/ci_optimizer/config.py
+++ b/src/ci_optimizer/config.py
@@ -1,4 +1,9 @@
 """User-configurable settings for the CI Agent system."""
+# 架构角色：配置层的核心文件，定义整个 CI Agent 系统的用户可配置参数。
+# 核心职责：通过 AgentConfig dataclass 集中管理所有运行时配置项，
+#           支持从 JSON 文件和环境变量两路加载，并以环境变量优先。
+# 关联模块：被 cli.py 用于初始化运行参数，被 tui/ 用于展示和修改配置，
+#           被 diagnose/ 用于读取故障诊断相关的模型和预算配置。
 
 import json
 import os
@@ -13,7 +18,12 @@ DEFAULT_MODEL = "claude-sonnet-4-20250514"
 
 @dataclass
 class AgentConfig:
-    """Configuration for the AI agent system."""
+    """Configuration for the AI agent system.
+
+    统一持有所有运行时配置，包括 LLM provider 选择、API 密钥、
+    Agent 行为参数（max_turns、language），以及故障诊断（diagnose_*）的
+    模型、采样率、每日费用上限等成本控制字段。
+    """
 
     # Provider: "anthropic" or "openai"
     provider: str = "anthropic"
@@ -48,6 +58,8 @@ class AgentConfig:
 
     def save(self):
         """Persist config to ~/.ci-agent/config.json."""
+        # 将当前配置序列化到用户主目录，供下次启动时复用。
+        # None 值不写入文件，避免覆盖掉未来版本的字段默认值。
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         data = asdict(self)
         # Don't persist None values
@@ -56,7 +68,11 @@ class AgentConfig:
 
     @classmethod
     def load(cls) -> "AgentConfig":
-        """Load config from file, env vars, with env vars taking priority."""
+        """Load config from file, env vars, with env vars taking priority.
+
+        加载优先级：默认值 < JSON 文件 < 环境变量。
+        环境变量始终覆盖文件配置，方便 CI 场景下无感注入密钥。
+        """
         config = cls()
 
         # Load from config file
@@ -94,6 +110,7 @@ class AgentConfig:
             config.diagnose_auto_on_webhook = env_auto.lower() in ("1", "true", "yes")
         if env_sample := os.getenv("DIAGNOSE_SAMPLE_RATE"):
             try:
+                # 强制钳位到 [0.0, 1.0]，防止调用方传入非法比率导致全量诊断失控
                 config.diagnose_sample_rate = max(0.0, min(1.0, float(env_sample)))
             except ValueError:
                 pass
@@ -111,7 +128,11 @@ class AgentConfig:
         return config
 
     def get_sdk_env(self) -> dict[str, str]:
-        """Build env dict for Claude Agent SDK."""
+        """Build env dict for Claude Agent SDK.
+
+        将配置中的 Anthropic 密钥和自定义 base URL 转成环境变量字典，
+        供底层 SDK 进程透传使用，避免全局污染 os.environ。
+        """
         env: dict[str, str] = {}
         if self.anthropic_api_key:
             env["ANTHROPIC_API_KEY"] = self.anthropic_api_key
@@ -120,19 +141,27 @@ class AgentConfig:
         return env
 
     def __post_init__(self):
+        # dataclass 初始化后的自检：将非法 provider 静默回退到默认值，
+        # 而非抛出异常，保持配置加载的容错性。
         if self.provider not in ("anthropic", "openai"):
             self.provider = "anthropic"
         if self.max_turns < 1:
             self.max_turns = 20
 
     def get_api_key(self) -> str | None:
-        """Get the API key for the configured provider."""
+        """Get the API key for the configured provider.
+
+        根据当前 provider 返回对应的 API key，调用方无需关心 provider 类型。
+        """
         if self.provider == "openai":
             return self.openai_api_key
         return self.anthropic_api_key
 
     def to_display_dict(self) -> dict:
-        """Return config as dict with sensitive values masked."""
+        """Return config as dict with sensitive values masked.
+
+        用于 TUI/CLI 展示配置时对密钥做脱敏处理，只显示前 8 位和后 4 位。
+        """
         d = asdict(self)
         for key_field in ("anthropic_api_key", "openai_api_key", "github_token"):
             if d.get(key_field):

--- a/src/ci_optimizer/db/__init__.py
+++ b/src/ci_optimizer/db/__init__.py
@@ -1,0 +1,7 @@
+"""ci_optimizer.db — 数据访问层包。
+
+对外暴露三个子模块：
+- models   : SQLAlchemy ORM 表定义（Repository / AnalysisReport / Finding / FailureDiagnosis）
+- database : 异步引擎、session 工厂以及启动时的 schema 初始化与迁移
+- crud     : 所有数据库读写操作的函数集合，上层业务代码统一通过此层访问数据库
+"""

--- a/src/ci_optimizer/db/crud.py
+++ b/src/ci_optimizer/db/crud.py
@@ -1,4 +1,10 @@
-"""CRUD operations for CI Agent database."""
+"""CRUD operations for CI Agent database.
+
+架构角色：数据访问层（DAL），将所有 SQL 逻辑集中到一处，上层服务只调用函数而无需编写 ORM 查询。
+核心职责：提供仓库、报告、发现项和失败诊断的增删改查接口，以及缓存命中判断和看板统计聚合。
+与其他模块的关系：依赖 models.py 的 ORM 类；被 FastAPI 路由、AI 技能、Webhook 处理器调用；
+database.py 提供 async_session 工厂注入此模块的每个函数。
+"""
 
 import hashlib
 from datetime import datetime, timedelta, timezone
@@ -11,7 +17,11 @@ from ci_optimizer.db.models import AnalysisReport, FailureDiagnosis, Finding, Re
 
 
 def compute_filters_hash(filters_json: str | None) -> str:
-    """Return a short deterministic hash for the given filters JSON string."""
+    """Return a short deterministic hash for the given filters JSON string.
+
+    生成过滤条件的 12 位 MD5 指纹，用作报告缓存的 key。
+    None 和空字符串视为等价（"无过滤"），统一映射到相同 hash。
+    """
     content = filters_json or ""
     return hashlib.md5(content.encode()).hexdigest()[:12]
 
@@ -22,7 +32,11 @@ async def find_cached_report(
     filters_hash: str,
     ttl_hours: int = 24,
 ) -> AnalysisReport | None:
-    """Return the most recent completed report matching the cache key within TTL."""
+    """Return the most recent completed report matching the cache key within TTL.
+
+    避免对同一仓库+过滤条件在 TTL 窗口内重复触发耗时的 LLM 分析。
+    仅返回 status="completed" 的报告，进行中或失败的记录不参与缓存命中。
+    """
     cutoff = datetime.now(timezone.utc) - timedelta(hours=ttl_hours)
     stmt = (
         select(AnalysisReport)
@@ -40,6 +54,10 @@ async def find_cached_report(
 
 
 async def get_or_create_repo(session: AsyncSession, owner: str, repo: str, url: str | None = None) -> Repository:
+    """查找或新建仓库记录，保证同一 owner/repo 只存在一行。
+
+    使用 flush 而非 commit，让调用方统一控制事务边界。
+    """
     stmt = select(Repository).where(Repository.owner == owner, Repository.repo == repo)
     result = await session.execute(stmt)
     db_repo = result.scalar_one_or_none()
@@ -56,6 +74,10 @@ async def create_report(
     filters_json: str | None = None,
     filters_hash: str | None = None,
 ) -> AnalysisReport:
+    """创建状态为 "running" 的报告占位行，分析完成后再由 complete_report 填充结果。
+
+    先写占位行的好处：即使分析过程中断，数据库里也有失败记录可供追溯。
+    """
     report = AnalysisReport(
         repo_id=repo_id,
         filters_json=filters_json,
@@ -75,6 +97,7 @@ async def complete_report(
     findings_data: list[dict],
     duration_ms: int,
 ) -> AnalysisReport:
+    """将分析结果写回报告行，同步批量插入 Finding 记录，并更新仓库的最后分析时间。"""
     stmt = select(AnalysisReport).where(AnalysisReport.id == report_id)
     result = await session.execute(stmt)
     report = result.scalar_one()
@@ -112,6 +135,7 @@ async def complete_report(
 
 
 async def fail_report(session: AsyncSession, report_id: int, error_message: str) -> None:
+    """将报告标记为 failed 并记录错误信息，供 UI 展示和后续重试判断。"""
     stmt = select(AnalysisReport).where(AnalysisReport.id == report_id)
     result = await session.execute(stmt)
     report = result.scalar_one()
@@ -121,6 +145,7 @@ async def fail_report(session: AsyncSession, report_id: int, error_message: str)
 
 
 async def get_report(session: AsyncSession, report_id: int) -> AnalysisReport | None:
+    """按 ID 查询单条报告，预加载 findings 和 repository，避免 N+1 懒加载问题。"""
     stmt = (
         select(AnalysisReport)
         .options(selectinload(AnalysisReport.findings), selectinload(AnalysisReport.repository))
@@ -137,6 +162,10 @@ async def list_reports(
     page: int = 1,
     limit: int = 20,
 ) -> tuple[list[AnalysisReport], int]:
+    """返回分页报告列表及总数，可选按 owner/repo 过滤。
+
+    total 与列表在同一事务内查询，保证分页数据一致性。
+    """
     stmt = (
         select(AnalysisReport)
         .options(selectinload(AnalysisReport.repository), selectinload(AnalysisReport.findings))
@@ -159,12 +188,14 @@ async def list_reports(
 
 
 async def list_repositories(session: AsyncSession) -> list[Repository]:
+    """返回所有仓库，按最近分析时间倒序排列，未分析过的仓库排在末尾（nullslast）。"""
     stmt = select(Repository).order_by(Repository.last_analyzed_at.desc().nullslast())
     result = await session.execute(stmt)
     return list(result.scalars().all())
 
 
 async def get_dashboard_stats(session: AsyncSession) -> dict:
+    """聚合看板所需的概览统计：仓库数、报告数、按严重程度和维度的发现项分布，以及最近 5 条报告。"""
     repo_count = await session.execute(select(func.count(Repository.id)))
     report_count = await session.execute(select(func.count(AnalysisReport.id)))
 
@@ -279,7 +310,7 @@ async def get_dashboard_trends(
     ]
 
     # ── Repo comparison: total findings per repo (latest report each) ──
-    # Subquery: latest completed report per repo
+    # 子查询：每个仓库只取最新一条已完成报告，避免历史数据重复计入跨仓库对比
     latest_report_sub = (
         select(
             AnalysisReport.repo_id,
@@ -395,7 +426,11 @@ async def save_diagnosis(
     cost_usd: float | None,
     source: str = "manual",
 ) -> FailureDiagnosis:
-    """Upsert a diagnosis keyed on (repo_id, run_id, run_attempt, tier)."""
+    """Upsert a diagnosis keyed on (repo_id, run_id, run_attempt, tier).
+
+    用 upsert 语义而非 insert-or-ignore：若已存在则用最新结果覆盖（支持 deep 升级 default）。
+    所有参数均为 keyword-only，防止调用方因参数顺序错误写入错误字段。
+    """
     existing = await find_cached_diagnosis(session, repo_id, run_id, run_attempt, tier)
     if existing is not None:
         existing.category = category

--- a/src/ci_optimizer/db/database.py
+++ b/src/ci_optimizer/db/database.py
@@ -1,4 +1,11 @@
-"""Database engine and session management."""
+"""Database engine and session management.
+
+架构角色：数据层的基础设施，负责 SQLite 连接管理和 schema 生命周期。
+核心职责：创建异步引擎与 session 工厂，在启动时执行 DDL 建表以及轻量级迁移。
+与其他模块的关系：被 FastAPI 应用启动事件调用 init_db()；
+async_session 工厂被所有 API 路由和服务通过依赖注入使用。
+项目不引入 Alembic，改用本模块内的 _COLUMN_MIGRATIONS 列表做增量列迁移。
+"""
 
 import logging
 from pathlib import Path
@@ -12,11 +19,13 @@ DEFAULT_DB_PATH = Path.home() / ".ci-agent" / "data.db"
 
 
 def get_engine(db_path: Path = DEFAULT_DB_PATH):
+    """创建并返回指向指定路径的异步 SQLite 引擎，自动建立父目录。"""
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
 
 
 engine = get_engine()
+# expire_on_commit=False：避免异步场景下 commit 后访问 ORM 属性时触发隐式 IO
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
@@ -34,7 +43,11 @@ _COLUMN_MIGRATIONS: list[tuple[str, str, str]] = [
 
 
 async def _apply_column_migrations(conn) -> None:
-    """Add missing columns to existing tables (SQLite-compatible no-op if present)."""
+    """Add missing columns to existing tables (SQLite-compatible no-op if present).
+
+    用 PRAGMA table_info 做幂等检查：列已存在则跳过，避免 ALTER TABLE 报错。
+    SQLite 不支持 IF NOT EXISTS 语法，因此必须手动查询列清单再决定是否执行。
+    """
     for table, column, ddl in _COLUMN_MIGRATIONS:
         result = await conn.execute(text(f"PRAGMA table_info({table})"))
         existing = {row[1] for row in result.fetchall()}  # row[1] is column name
@@ -45,7 +58,11 @@ async def _apply_column_migrations(conn) -> None:
 
 
 async def init_db():
-    """Create all tables if they don't exist, then apply additive migrations."""
+    """Create all tables if they don't exist, then apply additive migrations.
+
+    应用启动时调用一次。先用 SQLAlchemy metadata 创建全部表，
+    再补丁式追加新列，确保旧数据库平滑升级而无需停机迁移工具。
+    """
     from ci_optimizer.db.models import Base
 
     async with engine.begin() as conn:

--- a/src/ci_optimizer/db/models.py
+++ b/src/ci_optimizer/db/models.py
@@ -1,4 +1,11 @@
-"""SQLAlchemy ORM models for CI Agent."""
+"""SQLAlchemy ORM models for CI Agent.
+
+架构角色：数据层的基础，定义所有持久化实体的结构。
+核心职责：声明 ORM 表结构（Repository、AnalysisReport、Finding、FailureDiagnosis），
+并通过 relationship() 描述表间关联。
+与其他模块的关系：被 database.py 用于建表，被 crud.py 用于查询/写入，
+上层 API 路由和 AI 技能均通过 crud 间接依赖本模块。
+"""
 
 from datetime import datetime, timezone
 
@@ -12,6 +19,8 @@ class Base(DeclarativeBase):
 
 
 class Repository(Base):
+    """代表一个被追踪的 GitHub 仓库，是所有报告和诊断的根节点。"""
+
     __tablename__ = "repositories"
     __table_args__ = (sqlalchemy.UniqueConstraint("owner", "repo", name="uq_owner_repo"),)
 
@@ -25,6 +34,11 @@ class Repository(Base):
 
 
 class AnalysisReport(Base):
+    """一次 CI 分析任务的执行记录，包含输入过滤条件、执行状态和输出结果。
+
+    filters_hash 用于缓存命中判断：相同过滤条件的近期报告可直接复用，避免重复调用 LLM。
+    """
+
     __tablename__ = "analysis_reports"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -43,6 +57,8 @@ class AnalysisReport(Base):
 
 
 class Finding(Base):
+    """分析报告中的单条问题发现，细化到具体维度（效率/安全/成本/错误）和严重程度。"""
+
     __tablename__ = "findings"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -68,6 +84,11 @@ class FailureDiagnosis(Base):
     Natural key: (repo_id, run_id, run_attempt, tier). Uses repo_id FK but
     intentionally does NOT reference ci_runs yet — that table lands with
     issue #36 and this model must work standalone in v1.
+
+    针对单次失败 CI Run 的 AI 诊断结果。
+    tier 区分诊断深度（"default" 快速 / "deep" 深度），同一 run 在不同 tier 下可各存一条。
+    error_signature 是去噪后的错误哈希，用于跨 run 聚类相同根因，避免重复调用 LLM。
+    故意不外键关联 ci_runs 表（该表尚未落地），保证本模型可独立运行。
     """
 
     __tablename__ = "failure_diagnoses"

--- a/src/ci_optimizer/filters.py
+++ b/src/ci_optimizer/filters.py
@@ -1,4 +1,9 @@
 """Analysis filter definitions for CI pipeline analysis."""
+# 架构角色：数据过滤层的值对象（Value Object），描述"本次分析的范围"。
+# 核心职责：以 dataclass 封装时间范围、workflow 文件名、运行状态、分支等
+#           过滤条件，并提供与字典的互转方法，供 API 层和 CLI 层传递。
+# 关联模块：由 cli.py 从命令行参数构建，传入 prefetch.prepare_context()
+#           以缩小 GitHub API 查询范围；API 层通过 from_dict/to_dict 做序列化。
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -6,7 +11,11 @@ from datetime import datetime
 
 @dataclass
 class AnalysisFilters:
-    """Filters to narrow down the scope of CI analysis."""
+    """Filters to narrow down the scope of CI analysis.
+
+    所有字段均为可选（None 表示不过滤），调用方只需填写关心的维度。
+    None 字段在序列化时不写入 dict，保持传输结构精简。
+    """
 
     time_range: tuple[datetime, datetime] | None = None
     workflows: list[str] | None = None  # workflow file names, e.g. ["ci.yml"]
@@ -14,7 +23,10 @@ class AnalysisFilters:
     branches: list[str] | None = None  # branch names, e.g. ["main"]
 
     def to_dict(self) -> dict:
-        """Serialize filters to a JSON-safe dict."""
+        """Serialize filters to a JSON-safe dict.
+
+        时间范围转为 ISO 8601 字符串，方便跨进程传递和 JSON 存储。
+        """
         result: dict = {}
         if self.time_range:
             result["since"] = self.time_range[0].isoformat()
@@ -29,7 +41,10 @@ class AnalysisFilters:
 
     @classmethod
     def from_dict(cls, data: dict) -> "AnalysisFilters":
-        """Deserialize filters from a dict."""
+        """Deserialize filters from a dict.
+
+        to_dict() 的逆操作，用于从 API 请求体或缓存中还原过滤条件。
+        """
         time_range = None
         if "since" in data and "until" in data:
             time_range = (

--- a/src/ci_optimizer/github_client.py
+++ b/src/ci_optimizer/github_client.py
@@ -1,4 +1,11 @@
-"""GitHub REST API client for fetching CI run data."""
+"""GitHub REST API client for fetching CI run data.
+
+架构角色：外部数据源适配层，将 GitHub Actions REST API 封装为可复用的异步客户端。
+核心职责：获取 workflow runs、jobs、日志（整包 zip 和单 job 纯文本两种形式），
+以及仓库元数据、workflow 列表、运行时间和 Action ref 解析。
+与其他模块的关系：被 AI 技能（skill_runner）和 Webhook 处理器调用以拉取原始 CI 数据；
+AnalysisFilters 在此处被转换为 GitHub API 参数或客户端侧过滤条件。
+"""
 
 import asyncio
 import io
@@ -14,6 +21,8 @@ GITHUB_API_BASE = "https://api.github.com"
 
 
 class GitHubClient:
+    """封装 GitHub Actions REST API 的异步客户端，支持 Token 认证和限流自动重试。"""
+
     def __init__(self, token: str | None = None, config: "AgentConfig | None" = None):
         if config and config.github_token:
             self.token = config.github_token
@@ -22,6 +31,7 @@ class GitHubClient:
         self._client: httpx.AsyncClient | None = None
 
     async def _get_client(self) -> httpx.AsyncClient:
+        """懒加载 HTTP 客户端，同一实例复用连接池以减少握手开销。"""
         if self._client is None:
             headers = {"Accept": "application/vnd.github+json"}
             if self.token:
@@ -39,6 +49,11 @@ class GitHubClient:
             self._client = None
 
     async def _request(self, method: str, path: str, **kwargs) -> dict | list:
+        """统一请求入口，内置限流重试逻辑。
+
+        GitHub 有两类限速：主限速（X-RateLimit-Reset 头）和次级限速（Retry-After 头）。
+        等待时间上限为 120 秒，避免因极端情况导致无限挂起。
+        """
         client = await self._get_client()
         response = await client.request(method, path, **kwargs)
 
@@ -74,7 +89,10 @@ class GitHubClient:
         filters: AnalysisFilters | None = None,
         per_page: int = 30,
     ) -> list[dict]:
-        """Fetch recent workflow runs with optional filters."""
+        """Fetch recent workflow runs with optional filters.
+
+        GitHub API 只支持单值的 branch/status 过滤；多值情况改为客户端本地过滤。
+        """
         params: dict = {"per_page": per_page}
 
         if filters:
@@ -116,7 +134,11 @@ class GitHubClient:
         return data.get("jobs", [])
 
     async def get_run_logs(self, owner: str, repo: str, run_id: int, max_lines: int = 2000) -> str | None:
-        """Download and extract failure logs for a run. Returns truncated log text."""
+        """Download and extract failure logs for a run. Returns truncated log text.
+
+        GitHub 返回的是包含多个 job 日志文件的 ZIP；此处合并所有文件并取尾部行，
+        因为错误通常出现在运行末尾。BadZipFile 时降级为纯文本处理。
+        """
         client = await self._get_client()
         try:
             response = await client.get(
@@ -199,6 +221,9 @@ class GitHubClient:
         """Resolve a tag/branch ref to its full commit SHA.
 
         Tries tag ref first, then branch, returns None if not found.
+
+        先尝试 tag，再尝试 branch，顺序与 GitHub 官方推荐一致。
+        注解标签（annotated tag）需要额外一次请求跟随到真正的 commit SHA。
         """
         for ref_path in [f"tags/{ref}", f"heads/{ref}"]:
             try:

--- a/src/ci_optimizer/log_extractor.py
+++ b/src/ci_optimizer/log_extractor.py
@@ -4,6 +4,12 @@ Extracts the most relevant error excerpt from a raw CI log and computes
 a stable error signature that groups similar failures across runs.
 
 Kept intentionally dependency-free so it is trivial to unit-test.
+
+架构角色：纯函数工具层，在 GitHub 原始日志与 LLM 诊断之间做预处理。
+核心职责：从动辄数千行的 CI 日志中定位错误锚点、裁剪出关键片段，
+并将易变的运行时细节（时间戳、路径、数字）归一化为稳定签名，用于跨 run 聚类。
+与其他模块的关系：被失败诊断服务调用，输出的 (excerpt, signature) 作为 LLM prompt 的输入；
+无任何外部依赖，可直接单测。
 """
 
 from __future__ import annotations
@@ -46,6 +52,10 @@ def extract_error_excerpt(
         ``(excerpt, first_error_line)`` where ``first_error_line`` is the
         anchor line that was detected (used for signature hashing), or
         ``None`` if no anchor was found and we fell back to tail-only.
+
+    取最后一个锚点而非第一个：CI 日志里前期的 "error" 字样往往是无关警告，
+    真正导致 job 失败的错误几乎总在日志末尾。
+    窗口分配 1/3 前文 + 2/3 后文，因为堆栈跟踪通常出现在错误行之后。
     """
     if not log_text:
         return "", None
@@ -79,6 +89,9 @@ def compute_signature(
 
     Same error in two different runs (with different timestamps, hex IDs,
     line numbers) yields the same signature.
+
+    签名由"步骤名 | 归一化错误行"两部分拼接后取 MD5 前 12 位，
+    step 信息确保不同步骤的同类错误不会误判为同一根因。
     """
     step = (failing_step or "unknown").strip()
     line = _normalize_error_line(first_error_line or "")
@@ -97,7 +110,11 @@ def _find_last_anchor(lines: list[str]) -> int | None:
 
 
 def _normalize_error_line(line: str) -> str:
-    """Strip volatile substrings so the signature is stable across runs."""
+    """Strip volatile substrings so the signature is stable across runs.
+
+    按顺序替换：时间戳 → 十六进制地址 → 文件路径 → 裸数字，
+    最后截断至 200 字符防止超长行撑大 hash 输入。
+    """
     line = _RE_TIMESTAMP.sub("<TS>", line)
     line = _RE_HEX.sub("<HEX>", line)
     line = _RE_PATH.sub("/<PATH>", line)

--- a/src/ci_optimizer/prefetch.py
+++ b/src/ci_optimizer/prefetch.py
@@ -1,4 +1,10 @@
 """Pre-fetch GitHub data before agent analysis."""
+# 架构角色：数据准备层，负责在 Agent 分析开始前将所有所需数据从 GitHub API
+#           拉取到本地临时文件，让 Agent 可以直接读文件而无需实时调用网络。
+# 核心职责：按需（required_data 集合）获取 workflow 文件、runs、jobs、logs、
+#           action SHA、usage_stats，并计算聚合统计指标写入临时 JSON 文件。
+# 关联模块：由 cli.py 和 api/ 层调用；依赖 github_client.py 访问 GitHub API；
+#           产出的 AnalysisContext 对象传给 agents/orchestrator 作为分析输入。
 
 import asyncio
 import json
@@ -33,7 +39,11 @@ RUNNER_MULTIPLIERS = {
 
 @dataclass
 class AnalysisContext:
-    """All data needed for agent analysis, pre-fetched and saved locally."""
+    """All data needed for agent analysis, pre-fetched and saved locally.
+
+    各 *_json_path 字段指向临时文件，Agent 通过读文件获取数据，
+    避免在 LLM 上下文中携带大量原始 JSON。字段为 None 表示该数据未被请求或不可用。
+    """
 
     local_path: Path
     owner: str | None = None
@@ -63,7 +73,10 @@ _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 def _extract_action_refs(workflow_files: list[Path]) -> dict[str, tuple[str, str, str]]:
-    """Return {action_ref: (owner, repo, ref)} for all non-SHA action pins found in workflows."""
+    """Return {action_ref: (owner, repo, ref)} for all non-SHA action pins found in workflows.
+
+    只提取尚未固定到完整 SHA 的 action 引用，以便后续安全检查或自动 pin 建议。
+    """
     refs: dict[str, tuple[str, str, str]] = {}
     for wf in workflow_files:
         try:
@@ -87,7 +100,11 @@ async def _resolve_action_shas(
     refs: dict[str, tuple[str, str, str]],
     client: GitHubClient,
 ) -> dict[str, str]:
-    """Resolve each action ref to a full commit SHA. Returns {action@ref: sha}."""
+    """Resolve each action ref to a full commit SHA. Returns {action@ref: sha}.
+
+    并发解析，但通过 Semaphore(5) 限制并发数，防止触发 GitHub 二级速率限制。
+    gather 的 return_exceptions=True 确保单个失败不阻断其他解析。
+    """
     results: dict[str, str] = {}
 
     async def resolve_one(key: str, owner: str, repo: str, ref: str) -> None:
@@ -143,7 +160,11 @@ def _detect_runner_os(labels: list[str] | None) -> str:
 
 
 def _compute_usage_stats(runs: list[dict], all_jobs: dict[str, list[dict]]) -> dict:
-    """Compute usage statistics from runs and their jobs."""
+    """Compute usage statistics from runs and their jobs.
+
+    预先聚合出 per-workflow / per-job 的成功率、平均耗时、队列等待时间，
+    以及基于 GitHub 官方倍率的账单分钟数估算，避免 Agent 在 LLM 上下文中做大量计算。
+    """
     stats: dict = {
         "total_runs": len(runs),
         "total_jobs": 0,
@@ -227,6 +248,7 @@ def _compute_usage_stats(runs: list[dict], all_jobs: dict[str, list[dict]]) -> d
                 job_name_stats[job_name]["durations_ms"].append(exec_dur)
 
                 # Billing estimate: round up to nearest minute × multiplier
+                # GitHub 按整分钟向上取整计费；macOS × 10、Windows × 2 是官方倍率
                 minutes = exec_dur / 60000
                 billed = math.ceil(minutes)
                 multiplier = RUNNER_MULTIPLIERS.get(runner_os, 1)
@@ -307,6 +329,10 @@ async def prepare_context(
 
     required_data: set of data types to fetch. None = fetch all (backward compatible).
     Valid values: {"workflows", "runs", "jobs", "logs", "usage_stats"}
+
+    按需拉取数据的入口函数。required_data=None 时保持向后兼容（全量拉取）；
+    传入具体集合时只拉取必要数据，减少 API 调用次数和延迟。
+    usage_stats 隐式依赖 runs+jobs，函数内部会自动推导依赖关系。
     """
     ctx = AnalysisContext(
         local_path=resolved.local_path,
@@ -336,6 +362,8 @@ async def prepare_context(
 
     # Compute which data types are needed
     # Implicit dependency: usage_stats requires runs + jobs to compute
+    # 通过布尔推导将 required_data 集合展开成各类型的独立 need_* 标志，
+    # 便于后续条件分支判断，也使依赖关系显式可见
     need_all = required_data is None
     need_usage = need_all or "usage_stats" in required_data
     need_runs = need_all or "runs" in required_data or "jobs" in required_data or need_usage
@@ -366,6 +394,7 @@ async def prepare_context(
                         logger.warning(f"Failed to fetch jobs for run {run_id}: {e}")
                         continue
                     # Brief pause every 10 requests to stay under secondary rate limits
+                    # GitHub 对每分钟并发 API 请求有二级限制，每 10 次请求暂停 1 秒做流控
                     if (i + 1) % 10 == 0:
                         await asyncio.sleep(1)
                     all_jobs[str(run_id)] = [

--- a/src/ci_optimizer/report/formatter.py
+++ b/src/ci_optimizer/report/formatter.py
@@ -1,4 +1,14 @@
 """Report formatter — converts analysis results to Markdown and JSON."""
+# 架构角色：分析结果的序列化层，将 AnalysisResult 转换为多种可消费格式。
+# 核心职责：
+#   1. format_summary_markdown()  — 为 Web UI 顶部摘要区生成精简 Markdown（不含 findings 明细）
+#   2. format_markdown()          — 为 CLI 导出生成含完整 findings 表格和代码片段的详细报告
+#   3. format_json()              — 生成机器可读的 JSON 结构，供 API 或后续处理使用
+#   4. I18N 字典                  — 支持 en / zh 两种输出语言，通过 language 参数在调用时选择
+# 与其他模块的关系：
+#   - orchestrator.AnalysisResult 是输入数据结构，包含 findings、executive_summary、stats 等字段
+#   - prefetch.AnalysisContext 提供仓库元数据（owner/repo、workflow 文件列表、过滤条件）
+#   - API 层和 CLI 命令各自调用对应的 format_* 函数，formatter 本身无副作用
 
 import json
 from datetime import datetime, timezone
@@ -73,12 +83,9 @@ def _get_i18n(language: str) -> dict:
 
 
 def format_summary_markdown(result: AnalysisResult, ctx: AnalysisContext, language: str = "en") -> str:
-    """Format a concise executive summary for web display.
-
-    Only includes the top-level metadata and the LLM's executive_summary text.
-    The per-dimension findings are intentionally omitted — the web UI renders
-    them as interactive cards below this summary, so duplicating them here
-    makes the summary section excessively long.
+    """为 Web UI 顶部摘要区生成精简 Markdown，只含元数据头部和 executive_summary 文本。
+    有意省略 per-dimension findings——Web UI 会将它们渲染为下方的可交互卡片，
+    在此处重复会导致摘要区过长。
     """
     t = _get_i18n(language)
     repo_name = f"{ctx.owner}/{ctx.repo}" if ctx.owner else str(ctx.local_path)
@@ -107,7 +114,10 @@ def format_summary_markdown(result: AnalysisResult, ctx: AnalysisContext, langua
 
 
 def format_markdown(result: AnalysisResult, ctx: AnalysisContext, language: str = "en") -> str:
-    """Format analysis result as a full Markdown report (for CLI export)."""
+    """生成含完整 findings 表格和代码对比片段的详细 Markdown 报告，供 CLI 导出使用。
+    findings 先按 dimension 分组，每组先输出汇总表格，再输出带代码片段的详细描述。
+    表格单元格中的竖线字符需转义（\\|），防止破坏 Markdown 表格格式。
+    """
     t = _get_i18n(language)
     repo_name = f"{ctx.owner}/{ctx.repo}" if ctx.owner else str(ctx.local_path)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -213,7 +223,9 @@ def format_markdown(result: AnalysisResult, ctx: AnalysisContext, language: str 
 
 
 def format_json(result: AnalysisResult, ctx: AnalysisContext, language: str = "en") -> str:
-    """Format analysis result as JSON."""
+    """将分析结果序列化为 JSON 字符串，供 API 响应或机器消费使用。
+    若 ctx.usage_stats_json_path 存在，将其内容合并进输出（用于携带 token 用量统计）。
+    """
     repo_name = f"{ctx.owner}/{ctx.repo}" if ctx.owner else str(ctx.local_path)
 
     # Load usage stats if available

--- a/src/ci_optimizer/resolver.py
+++ b/src/ci_optimizer/resolver.py
@@ -1,4 +1,9 @@
 """Input resolver: detect local path vs GitHub URL and extract repo info."""
+# 架构角色：输入解析层，是用户提供的仓库标识（URL/简称/本地路径）进入系统的第一关。
+# 核心职责：将三种输入形式统一规范化为 ResolvedInput（本地路径 + owner/repo 元信息），
+#           必要时执行 shallow clone 将远程仓库拉取到本地临时目录。
+# 关联模块：由 cli.py 和 api/ 层调用，产出的 ResolvedInput 直接传给 prefetch.prepare_context()。
+#           本文件不依赖任何 ci_optimizer 内部模块，保持低耦合。
 
 import re
 import shutil
@@ -15,6 +20,12 @@ GITHUB_SHORTHAND_PATTERN = re.compile(r"^([a-zA-Z0-9\-_.]+)/([a-zA-Z0-9\-_.]+)$"
 
 @dataclass
 class ResolvedInput:
+    """统一表示已解析的仓库输入，无论来源是 URL、简称还是本地路径。
+
+    temp_dir 非空时表示 resolver 克隆了远程仓库，调用方在分析结束后
+    应负责清理该临时目录（当前由 GC/OS 清理，未显式 cleanup）。
+    """
+
     local_path: Path
     owner: str | None = None
     repo: str | None = None
@@ -27,7 +38,11 @@ def is_github_url(input_str: str) -> bool:
 
 
 def is_github_shorthand(input_str: str) -> bool:
-    """Check if input is 'owner/repo' shorthand (not a local path)."""
+    """Check if input is 'owner/repo' shorthand (not a local path).
+
+    需要额外检查路径是否真实存在，因为 "foo/bar" 格式同时也是合法的相对路径，
+    用文件系统存在性来消歧义：存在即本地路径，不存在才视为 GitHub 简称。
+    """
     if GITHUB_SHORTHAND_PATTERN.match(input_str):
         # Make sure it's not an existing local path
         return not Path(input_str).exists()
@@ -43,7 +58,11 @@ def parse_github_url(url: str) -> tuple[str, str]:
 
 
 def detect_github_remote(local_path: Path) -> tuple[str, str] | None:
-    """Parse owner/repo from a local git repo's remote URL."""
+    """Parse owner/repo from a local git repo's remote URL.
+
+    对本地仓库自动提取 GitHub owner/repo，以便即使用户传的是本地路径，
+    也能调用 GitHub API 获取 runs/jobs 数据。同时兼容 SSH 和 HTTPS 两种 remote 格式。
+    """
     git_config = local_path / ".git" / "config"
     if not git_config.exists():
         return None
@@ -75,7 +94,11 @@ def detect_github_remote(local_path: Path) -> tuple[str, str] | None:
 
 
 def clone_repo(url: str, timeout: int = 120) -> tuple[Path, str]:
-    """Shallow clone a GitHub repo to a temp directory. Returns (path, temp_dir)."""
+    """Shallow clone a GitHub repo to a temp directory. Returns (path, temp_dir).
+
+    使用 --depth=1 浅克隆，只取最新快照以减少网络传输量；
+    失败时主动清理临时目录，避免残留文件占用磁盘。
+    """
     temp_dir = tempfile.mkdtemp(prefix="ci-agent-")
     try:
         subprocess.run(
@@ -105,6 +128,10 @@ def resolve_input(input_str: str) -> ResolvedInput:
       - GitHub URL: https://github.com/owner/repo
       - Shorthand: owner/repo (auto-expands to GitHub URL)
       - Local path: /path/to/repo or ./repo
+
+    优先级：GitHub URL > owner/repo 简称 > 本地路径。
+    本地路径会进一步尝试从 git remote 推断 owner/repo，
+    使本地仓库也能享受 GitHub API 数据。
     """
     if is_github_url(input_str):
         owner, repo = parse_github_url(input_str)

--- a/src/ci_optimizer/tui/__init__.py
+++ b/src/ci_optimizer/tui/__init__.py
@@ -1,1 +1,9 @@
 """Interactive TUI for ci-agent."""
+# tui 包的公共入口，对外只暴露包名，具体功能通过子模块访问：
+#   tui.app       — TUI 总入口（run_tui）
+#   tui.commands  — 斜杠命令解析
+#   tui.panels    — 写入确认面板
+#   tui.renderer  — 会话统计渲染
+#   tui.repl      — PromptSession 配置
+#   tui.context   — 仓库检测与确认
+#   tui.setup     — 首次配置向导

--- a/src/ci_optimizer/tui/app.py
+++ b/src/ci_optimizer/tui/app.py
@@ -323,12 +323,12 @@ async def _query_via_server(
 
 async def run_tui(repo_path: Path | None = None) -> None:
     """TUI 主入口，完整生命周期：
-      1. 打印 banner
-      2. 首次运行 → setup wizard；否则 → config review（可跳过逐项修改）
-      3. 检测并确认 Git 仓库（支持手动切换路径）
-      4. 确保后端 Server 就绪（自动拉起或复用已有进程）
-      5. 进入 REPL：读输入 → 分发斜杠命令 / 发送 /api/chat → 渲染响应
-      6. 退出时清理自动拉起的 Server 子进程
+    1. 打印 banner
+    2. 首次运行 → setup wizard；否则 → config review（可跳过逐项修改）
+    3. 检测并确认 Git 仓库（支持手动切换路径）
+    4. 确保后端 Server 就绪（自动拉起或复用已有进程）
+    5. 进入 REPL：读输入 → 分发斜杠命令 / 发送 /api/chat → 渲染响应
+    6. 退出时清理自动拉起的 Server 子进程
     """
     console = Console()
     renderer = StreamRenderer(console=console)

--- a/src/ci_optimizer/tui/app.py
+++ b/src/ci_optimizer/tui/app.py
@@ -1,4 +1,16 @@
 """TUI entry point: startup banner, repo confirm, REPL loop."""
+# 架构角色：TUI 层的总入口，负责将所有子模块串联成完整的交互式终端体验。
+# 核心职责：
+#   1. 启动 banner → setup wizard / config review → 仓库确认 → 自动拉起后端 Server
+#   2. 驱动主 REPL 循环：读取用户输入 → 分发斜杠命令或调用 /api/chat SSE 流
+#   3. 消费 SSE 事件（text / tool_use / tool_result / write_proposal / done / error）
+#   4. SSE 流结束后，若有 write_proposal 则转给 panels.confirm_action 走确认流程
+# 与其他模块的关系：
+#   - commands.py  负责斜杠命令的解析与执行
+#   - renderer.py  负责统计 token/花费，并提供 console 引用
+#   - panels.py    负责写入确认面板 UI
+#   - context.py   负责检测并确认 Git 仓库
+#   - setup.py     负责首次配置向导和每次启动时的配置复核
 
 from __future__ import annotations
 
@@ -35,7 +47,9 @@ _COST_TABLE = {
 
 
 def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
-    """Rough USD cost estimate based on model name prefix."""
+    """基于模型名称前缀粗略估算本次请求的 USD 花费。
+    用模型名子串匹配而非精确匹配，兼容带版本号的完整模型 ID（如 claude-sonnet-4-5）。
+    """
     model_lower = model.lower()
     for key, (in_price, out_price) in _COST_TABLE.items():
         if key in model_lower:
@@ -64,7 +78,7 @@ def _print_connected(console: Console, ctx: RepoContext, config: AgentConfig, se
 
 
 async def _check_server(server_url: str) -> bool:
-    """Check if the CI Agent server is reachable."""
+    """探测后端 Server 是否已在运行（GET /health），超时 3s 视为不可达。"""
     try:
         async with httpx.AsyncClient(timeout=3) as client:
             resp = await client.get(f"{server_url}/health")
@@ -74,7 +88,7 @@ async def _check_server(server_url: str) -> bool:
 
 
 def _start_server_background(port: int = 8000) -> subprocess.Popen:
-    """Start the CI Agent server as a background process."""
+    """在子进程中启动 uvicorn，stdout/stderr 静默丢弃，避免污染 TUI 终端。"""
     import sys
 
     proc = subprocess.Popen(
@@ -86,7 +100,9 @@ def _start_server_background(port: int = 8000) -> subprocess.Popen:
 
 
 async def _ensure_server(server_url: str, console: Console) -> subprocess.Popen | None:
-    """Ensure the server is running. Start it automatically if not."""
+    """确保后端 Server 就绪。若未运行则自动拉起，最多等待 10s（轮询 0.5s/次）。
+    返回子进程句柄（由调用方在退出时 terminate），Server 已在运行则返回 None。
+    """
     from rich.live import Live
     from rich.text import Text
 
@@ -141,7 +157,9 @@ async def _handle_write_proposals(
     renderer: "StreamRenderer",
     server_url: str,
 ) -> None:
-    """Route write proposals through panels.confirm_action for unified UX."""
+    """将 SSE write_proposal 事件中的变更列表路由至确认面板，并在用户确认后调用 /api/chat/apply 落盘。
+    用户可选 YES（文件+commit）、EDIT_ONLY（只写文件跳过 git）、NO（取消）。
+    """
     console = renderer.console
 
     file_proposals = [p for p in proposals if p.get("action") in ("write_file", "edit_file")]
@@ -194,7 +212,15 @@ async def _query_via_server(
     conversation: list[dict],
     server_url: str,
 ) -> None:
-    """Send user input to the server's /api/chat SSE endpoint and stream output."""
+    """将用户消息 POST 到 /api/chat，逐行消费 SSE 事件流并实时渲染到终端。
+    事件类型处理逻辑：
+      text         → 累积文本块，用 · 进度点提示流式输出进行中
+      tool_use     → 打印"正在执行工具"状态行
+      tool_result  → 打印工具执行结果摘要
+      write_proposal → 暂存变更提案，等待 done 事件后统一弹确认面板
+      done         → 渲染完整 AI 回复（Markdown）+ token/花费统计
+      error        → 抛出异常，由 REPL 捕获并显示红色错误提示
+    """
     conversation.append({"role": "user", "content": user_input})
 
     payload = {
@@ -296,7 +322,14 @@ async def _query_via_server(
 
 
 async def run_tui(repo_path: Path | None = None) -> None:
-    """Main TUI entry point: banner → repo confirm → REPL loop."""
+    """TUI 主入口，完整生命周期：
+      1. 打印 banner
+      2. 首次运行 → setup wizard；否则 → config review（可跳过逐项修改）
+      3. 检测并确认 Git 仓库（支持手动切换路径）
+      4. 确保后端 Server 就绪（自动拉起或复用已有进程）
+      5. 进入 REPL：读输入 → 分发斜杠命令 / 发送 /api/chat → 渲染响应
+      6. 退出时清理自动拉起的 Server 子进程
+    """
     console = Console()
     renderer = StreamRenderer(console=console)
 

--- a/src/ci_optimizer/tui/commands.py
+++ b/src/ci_optimizer/tui/commands.py
@@ -1,4 +1,9 @@
 """Slash command parser and handlers."""
+# 架构角色：斜杠命令的统一解析与分发层，与业务逻辑完全解耦。
+# 核心职责：识别 / 开头的用户输入，路由到对应处理函数，返回 CommandResult 告知调用方后续动作。
+# 与其他模块的关系：
+#   - app.py 在 REPL 循环中调用 is_command() + execute()，根据 CommandResult.quit 决定是否退出
+#   - renderer.py 的 StreamRenderer 作为参数传入，用于 /cost 命令展示统计
 
 from __future__ import annotations
 
@@ -14,7 +19,9 @@ if TYPE_CHECKING:
 
 @dataclass
 class CommandResult:
-    """Result of executing a slash command."""
+    """斜杠命令执行结果，供 app.py 的 REPL 循环读取后续动作标志。
+    quit=True 时 REPL 立即退出；clear_history=True 时 app.py 可选择清理 UI 状态。
+    """
 
     handled: bool = True
     clear_history: bool = False
@@ -34,7 +41,9 @@ def execute(
     conversation: list,
     model: str,
 ) -> CommandResult:
-    """Parse and execute a slash command. Returns a CommandResult."""
+    """解析并执行斜杠命令，返回 CommandResult。
+    app.py 已保证只在 is_command() 为 True 时调用此函数，无需重复校验。
+    """
     parts = text.strip().split(maxsplit=1)
     cmd = parts[0].lower()
     arg = parts[1] if len(parts) > 1 else ""
@@ -95,6 +104,7 @@ def _cmd_model(console: Console, arg: str, current: str) -> CommandResult:
     else:
         console.print(f"模型已切换为: [bold]{arg}[/bold]")
         # The caller is responsible for actually updating the model in config.
+        # 注：实际写入 config.model 的逻辑在 app.py 的 REPL 中，此处只打印提示。
     return CommandResult()
 
 
@@ -136,7 +146,9 @@ def _cmd_repo(console: Console, arg: str) -> CommandResult:
 
 
 def _cmd_compact(console: Console, conversation: list) -> CommandResult:
-    """Keep only the most recent 6 messages to free context window."""
+    """保留最近 KEEP 条消息，丢弃更早的历史，释放上下文窗口占用。
+    直接对 conversation 列表原地截断，避免创建新列表引用失效。
+    """
     KEEP = 6
     total = len(conversation)
     if total <= KEEP:

--- a/src/ci_optimizer/tui/context.py
+++ b/src/ci_optimizer/tui/context.py
@@ -1,4 +1,12 @@
 """Repository detection and user confirmation for TUI startup."""
+# 架构角色：TUI 启动流程中的仓库感知层，在进入 REPL 前完成仓库上下文的建立。
+# 核心职责：
+#   1. 通过 git 命令探测当前目录所在的 Git 工作树根、分支、最近提交
+#   2. 调用 resolver 模块解析 GitHub remote，得到 owner/repo
+#   3. 用 confirm_repo() 交互式地让用户确认或手动切换仓库路径
+# 与其他模块的关系：
+#   - app.py 在 setup 之后调用 detect_repo() + confirm_repo() 得到 RepoContext
+#   - RepoContext 在整个 REPL 生命周期内作为仓库元数据随每次 /api/chat 请求一起发送
 
 import subprocess
 from dataclasses import dataclass
@@ -9,7 +17,9 @@ from ci_optimizer.resolver import detect_github_remote
 
 @dataclass
 class RepoContext:
-    """Detected repository information."""
+    """已检测到的 Git 仓库上下文，贯穿整个 TUI 会话生命周期。
+    display_name 属性在 owner/repo 已知时返回 GitHub 格式，否则降级为目录名。
+    """
 
     local_path: Path
     owner: str | None = None
@@ -25,7 +35,9 @@ class RepoContext:
 
 
 def _git_output(cwd: Path, *args: str) -> str | None:
-    """Run a git command and return stripped stdout, or None on failure."""
+    """在指定目录执行 git 子命令，返回去除首尾空白的 stdout；超时或命令失败则返回 None。
+    timeout=5 防止在挂载网络盘等慢路径上卡住 TUI 启动。
+    """
     try:
         result = subprocess.run(
             ["git", *args],
@@ -42,9 +54,8 @@ def _git_output(cwd: Path, *args: str) -> str | None:
 
 
 def detect_repo(path: Path | None = None) -> RepoContext | None:
-    """Detect a git repository at *path* (defaults to cwd).
-
-    Returns a RepoContext if the path is inside a git worktree, else None.
+    """在 path（默认 cwd）处探测 Git 仓库，构建并返回 RepoContext。
+    若路径不在任何 Git 工作树中，返回 None（由调用方决定如何提示用户）。
     """
     path = (path or Path.cwd()).resolve()
 
@@ -71,10 +82,9 @@ def detect_repo(path: Path | None = None) -> RepoContext | None:
 
 
 async def confirm_repo(ctx: RepoContext | None) -> RepoContext:
-    """Interactive prompt to confirm or switch the working repository.
-
-    Uses prompt_toolkit's async API to avoid nested event loop issues.
-    Returns the confirmed RepoContext.
+    """交互式确认或切换工作仓库，返回最终生效的 RepoContext。
+    使用 prompt_toolkit 的 async API，与 asyncio 事件循环兼容，避免嵌套循环问题。
+    用户输入 'q' 或 EOFError 时抛出 EOFError，由 app.py 捕获后优雅退出。
     """
     from prompt_toolkit import PromptSession
     from rich.console import Console

--- a/src/ci_optimizer/tui/panels.py
+++ b/src/ci_optimizer/tui/panels.py
@@ -1,4 +1,12 @@
 """Write-confirmation panel and diff viewer."""
+# 架构角色：TUI 层的 Rich 渲染组件，专门负责"写入确认"这一交互环节。
+# 核心职责：
+#   1. 将 SSE write_proposal 数据结构化为 WriteAction / FileChange 数据类
+#   2. 用 Rich Panel 渲染变更摘要（红色边框警示用户即将落盘）
+#   3. 阻塞式等待用户输入 y/n/d/e，支持循环展示 diff 后再选择
+# 与其他模块的关系：
+#   - app.py 的 _handle_write_proposals() 构建 WriteAction 并调用 confirm_action()
+#   - 返回的 ConfirmChoice 枚举决定 app.py 是否以及以何种方式调用 /api/chat/apply
 
 from __future__ import annotations
 
@@ -11,6 +19,10 @@ from rich.syntax import Syntax
 
 
 class ConfirmChoice(Enum):
+    """用户在写入确认面板中的选择。
+    EDIT_ONLY 表示只写文件、跳过 git commit 和 PR，适合用户想手动控制提交的场景。
+    """
+
     YES = "y"
     NO = "n"
     DIFF = "d"
@@ -19,7 +31,7 @@ class ConfirmChoice(Enum):
 
 @dataclass
 class FileChange:
-    """A single file modification."""
+    """单个文件的变更描述，由 SSE write_proposal 事件的 proposals 列表中解析而来。"""
 
     path: str
     added: int = 0
@@ -29,7 +41,7 @@ class FileChange:
 
 @dataclass
 class WriteAction:
-    """An action that modifies the repo and needs confirmation."""
+    """需要用户二次确认的写入操作集合，可同时包含文件修改和 git commit。"""
 
     files: list[FileChange] = field(default_factory=list)
     commit_message: str | None = None
@@ -38,10 +50,8 @@ class WriteAction:
 
 
 async def confirm_action(action: WriteAction, console: Console | None = None) -> ConfirmChoice:
-    """Show a red-bordered confirmation panel for a write action.
-
-    Returns the user's choice. If the user picks 'd' (diff), the diff is
-    shown inline and the prompt re-appears.
+    """显示红色边框确认面板，阻塞等待用户输入并返回选择。
+    选择 'd' 时展示 unified diff 后重新提示，不退出循环——这是唯一的循环出口条件。
     """
     from prompt_toolkit import PromptSession
 

--- a/src/ci_optimizer/tui/renderer.py
+++ b/src/ci_optimizer/tui/renderer.py
@@ -1,4 +1,11 @@
 """Rich-based stream stats tracker for the TUI."""
+# 架构角色：会话级统计数据的持有者和展示模块，是 app.py 与 Rich Console 之间的薄包装层。
+# 核心职责：
+#   1. 通过 SessionStats 跨轮次累积 token 花费和查询次数
+#   2. 提供 print_stats() 供 /cost 命令调用
+# 与其他模块的关系：
+#   - app.py 在每次 SSE done 事件后更新 renderer.stats，并将 renderer 作为共享引用传递
+#   - commands.py 的 _cmd_cost() 通过 renderer.print_stats() 读取统计数据
 
 from __future__ import annotations
 
@@ -9,7 +16,7 @@ from rich.console import Console
 
 @dataclass
 class SessionStats:
-    """Accumulated stats for the current session."""
+    """单次 TUI 会话的累计统计：总花费（USD）和已执行的查询轮次。"""
 
     total_cost_usd: float = 0.0
     query_count: int = 0
@@ -17,7 +24,9 @@ class SessionStats:
 
 @dataclass
 class StreamRenderer:
-    """Tracks session stats and provides a print_stats helper."""
+    """持有 Rich Console 和 SessionStats，作为 app.py 中跨函数共享的渲染上下文对象。
+    设计为 dataclass 而非普通类，方便在函数间以单一引用传递，避免 console/stats 各自散落。
+    """
 
     console: Console = field(default_factory=Console)
     stats: SessionStats = field(default_factory=SessionStats)

--- a/src/ci_optimizer/tui/repl.py
+++ b/src/ci_optimizer/tui/repl.py
@@ -1,4 +1,11 @@
 """prompt_toolkit REPL session with history and key bindings."""
+# 架构角色：输入层配置模块，封装 prompt_toolkit 的 PromptSession 构建细节。
+# 核心职责：
+#   1. 配置持久化历史文件（~/.ci-agent/history），让用户可用上下箭头翻历史
+#   2. 注册斜杠命令的自动补全（WordCompleter）
+#   3. 绑定 Ctrl+C（清空输入）、Ctrl+D（退出）、Alt+Enter（多行换行）
+# 与其他模块的关系：
+#   - app.py 调用 build_session() 获取 PromptSession，在 REPL 循环中通过 prompt_async() 读取用户输入
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
@@ -13,7 +20,10 @@ SLASH_COMMANDS = ["/help", "/repo", "/skills", "/clear", "/cost", "/compact", "/
 
 
 def build_session() -> PromptSession:
-    """Create a configured PromptSession with history, completion, and key bindings."""
+    """构建并返回配置好的 PromptSession。
+    CONFIG_DIR 在此处按需创建（parents=True），保证历史文件路径有效。
+    multiline=False 保持单行提交语义；多行输入通过 Alt+Enter 注入换行符实现。
+    """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
     completer = WordCompleter(SLASH_COMMANDS, sentence=True)

--- a/src/ci_optimizer/tui/setup.py
+++ b/src/ci_optimizer/tui/setup.py
@@ -1,4 +1,13 @@
 """First-run setup wizard and config review for TUI."""
+# 架构角色：TUI 启动前的配置生命周期管理模块。
+# 核心职责：
+#   1. needs_setup()：判断是否首次运行（config.json 不存在）
+#   2. run_setup_wizard()：引导用户完成 provider / API Key / GitHub Token / model / language 五步配置
+#   3. run_config_review()：非首次启动时展示现有配置，允许用户逐项修改
+#   4. verify_api()：用最小请求（max_tokens=16）验证 API Key 连通性，提前暴露配置错误
+# 与其他模块的关系：
+#   - app.py 在 banner 之后、仓库检测之前调用本模块，确保配置就绪再进入 REPL
+#   - AgentConfig（来自 config 模块）是配置的持久化载体，setup.py 负责填充并 save()
 
 from __future__ import annotations
 
@@ -13,12 +22,12 @@ from ci_optimizer.config import CONFIG_FILE, DEFAULT_MODEL, AgentConfig
 
 
 def needs_setup() -> bool:
-    """Return True if config.json does not exist (first run)."""
+    """判断是否需要运行 setup wizard（config.json 尚不存在即视为首次运行）。"""
     return not CONFIG_FILE.exists()
 
 
 def mask_key(value: str | None) -> str:
-    """Mask a sensitive value for display."""
+    """对 API Key 等敏感值做脱敏显示（保留头 8 位和尾 4 位，中间替换为 ...）。"""
     if not value:
         return "(未设置)"
     if len(value) > 12:
@@ -33,9 +42,8 @@ async def verify_api(
     base_url: str | None = None,
     anthropic_base_url: str | None = None,
 ) -> tuple[bool, str]:
-    """Send a lightweight API call to verify connectivity.
-
-    Returns (success: bool, message: str).
+    """发送一次极小请求（max_tokens=16, content="hi"）验证 API 连通性，返回 (成功, 描述消息)。
+    分别处理网络错误、超时、HTTP 401/403，给出明确的中文提示而非原始异常堆栈。
     """
     try:
         if provider == "openai":
@@ -101,7 +109,9 @@ async def _verify_openai(api_key: str, model: str, base_url: str | None) -> tupl
 
 
 async def run_setup_wizard(console: Console) -> AgentConfig:
-    """Run the full first-time setup wizard. Returns configured AgentConfig."""
+    """首次运行时的完整配置向导，按顺序引导用户完成 5 步配置后保存并验证 API。
+    配置完成后调用 _run_verify() 立即验证连通性，提前发现 Key 错误。
+    """
     console.print(
         Panel(
             "[bold]首次使用，需要进行初始配置[/bold]",
@@ -171,7 +181,9 @@ async def run_setup_wizard(console: Console) -> AgentConfig:
 
 
 async def run_config_review(console: Console, config: AgentConfig) -> AgentConfig:
-    """Show current config and let user modify each item. Returns updated config."""
+    """非首次启动时展示当前配置，逐项询问是否修改，有变更则自动保存，最后验证 API。
+    即使用户全部选 N 跳过，也会执行一次 API 验证，确保每次启动都能及时发现 Key 过期。
+    """
     session = PromptSession()
     changed = False
 
@@ -255,7 +267,9 @@ async def run_config_review(console: Console, config: AgentConfig) -> AgentConfi
 
 
 async def _run_verify(console: Console, config: AgentConfig) -> None:
-    """Run API verification and print result."""
+    """调用 verify_api() 并将结果以绿色（成功）或红色（失败）打印到 console。
+    API Key 为空时跳过验证，避免向 None 发起无意义的网络请求。
+    """
     api_key = config.get_api_key()
     if not api_key:
         console.print("[yellow]⚠ 未设置 API Key，跳过连通性验证[/yellow]")


### PR DESCRIPTION
## Summary

- 覆盖 **tui / api / agents / db / core** 五个层次，共 39 个 Python 文件
- 每个文件新增文件头注解（架构角色 + 核心职责 + 与其他模块关系）
- 关键类/函数补充中文 docstring，解释「为什么」而非重复代码
- 内联注释仅标注非显而易见的逻辑（边界处理、性能权衡、设计决策）
- **零业务逻辑改动**，仅新增注释，843 行插入 / 140 行替换原有英文 docstring

## 背景

为方便后续阅读架构（包括 issue #44 记忆/任务/规划模块的实现），给整个代码库补齐中文注解，打开任何文件都能在文件头看到它在系统中的定位。

## Test plan

- [ ] 确认 `ruff check src/` 无新增 lint 错误
- [ ] 确认 `pytest` 全部测试通过（注释不影响运行时行为）

🤖 Generated with [Claude Code](https://claude.com/claude-code)